### PR TITLE
Update multi-paragraph integration test to use block markup

### DIFF
--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -380,12 +380,12 @@ export async function runIntegrationTests(runTest) {
             async execute() {
                 const { elements, cleanup } = setupControllerFixture();
                 try {
-                    const multiParagraphText = [
-                        "Paragraph #1.",
-                        "Paragraph #2.",
-                        "Paragraph #3."
-                    ].join("\n\n");
-                    elements.editorElement.textContent = multiParagraphText;
+                    const multiParagraphMarkup = [
+                        "<div>Paragraph #1.</div>",
+                        "<div>Paragraph #2.</div>",
+                        "<div>Paragraph #3.</div>"
+                    ].join("");
+                    elements.editorElement.innerHTML = multiParagraphMarkup;
                     elements.editorElement.dispatchEvent(new Event("input"));
                     await waitForAnimationFrame();
 


### PR DESCRIPTION
## Summary
- update the multi-paragraph integration test to populate the editor with block-level markup
- ensure the test continues to assert the existing paragraph and word counts

## Testing
- npm test *(fails: missing happy-dom dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d618bff5a08327a028180643140b60