### PR TITLE
Handle editor spacer divs during snapshot serialization

### DIFF
--- a/js/ui/inputPanel.js
+++ b/js/ui/inputPanel.js
@@ -18,6 +18,7 @@ const SINGLE_NEWLINE = "\n";
 /** @type {string} */
 const DOUBLE_NEWLINE = "\n\n";
 const PLACEHOLDER_SEPARATOR_FLAG = Symbol("placeholderSeparatorFlag");
+const TRAILING_NEWLINE_PATTERN = /\n+$/u;
 
 /**
  * Normalizes editor text content by replacing non-breaking spaces and Windows newlines.
@@ -253,7 +254,10 @@ export class InputPanel {
         inertEditor.childNodes.forEach((childNode) => {
             if (childNode instanceof window.Text) {
                 const textContent = childNode.textContent || "";
-                const normalizedText = normalizeEditorText(textContent);
+                const normalizedText = normalizeEditorText(textContent).replace(
+                    TRAILING_NEWLINE_PATTERN,
+                    ""
+                );
                 if (normalizedText.trim().length === 0) {
                     return;
                 }
@@ -264,11 +268,15 @@ export class InputPanel {
             if (childNode instanceof HTMLElement) {
                 const element = childNode;
                 const normalizedInnerText = normalizeEditorText(element.innerText);
-                if (isEmptyOrNewlineOnly(normalizedInnerText)) {
+                const trimmedInnerText = normalizedInnerText.replace(
+                    TRAILING_NEWLINE_PATTERN,
+                    ""
+                );
+                if (isEmptyOrNewlineOnly(trimmedInnerText)) {
                     placeholderSegments.push(PLACEHOLDER_SEPARATOR_FLAG);
                     return;
                 }
-                placeholderSegments.push(normalizedInnerText);
+                placeholderSegments.push(trimmedInnerText);
             }
         });
 

--- a/tests/inputPanel.test.js
+++ b/tests/inputPanel.test.js
@@ -9,7 +9,8 @@ import { assertEqual } from "./assert.js";
 const SNAPSHOT_ASSERTION_MESSAGES = Object.freeze({
     placeholderMismatch: "Snapshot placeholder text should match expected newline separated paragraphs",
     plainTextMismatch: "Snapshot plain text should match expected newline separated paragraphs",
-    serializedLengthMismatch: "Serialized text should match the expected character length"
+    serializedLengthMismatch: "Serialized placeholder text should match the expected character length",
+    plainTextLengthMismatch: "Snapshot plain text should match the expected character length"
 });
 
 const PARAGRAPH_TEXT_CONTENT = Object.freeze({
@@ -235,6 +236,11 @@ export async function runInputPanelTests(runTest) {
                         snapshot.placeholderText.length,
                         documentCase.expectedLength,
                         SNAPSHOT_ASSERTION_MESSAGES.serializedLengthMismatch
+                    );
+                    assertEqual(
+                        snapshot.plainText.length,
+                        documentCase.expectedLength,
+                        SNAPSHOT_ASSERTION_MESSAGES.plainTextLengthMismatch
                     );
                 }
             } finally {


### PR DESCRIPTION
## Plan
- Trim trailing editor-generated breaks before serializing placeholder text
- Treat blank spacer divs as separator flags so they collapse correctly

## Summary
- Added a trailing newline pattern to remove editor-emitted break characters before collecting placeholder segments
- Treated sanitized empty block nodes as separator flags so spacer divs collapse to single newlines while preserving intentional blank paragraphs

## Testing
- npm run test:headless
- npm run test:browser *(fails: missing libatk-1.0 shared library in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d716550f008327bf64b474140a0efc