### PR TITLE
Ensure spacer separators serialize as double newlines

### DIFF
--- a/js/ui/inputPanel.js
+++ b/js/ui/inputPanel.js
@@ -30,6 +30,21 @@ function normalizeEditorText(text) {
 }
 
 /**
+ * Serializes an element's text content, converting soft breaks to newline characters.
+ * @param {HTMLElement} element Element whose textual content should be extracted.
+ * @returns {string} Text content with `<br>` tags replaced by newline characters.
+ */
+function serializeElementTextWithSoftBreaks(element) {
+    const inertDocument = document.implementation.createHTMLDocument("element-text-serialization");
+    const clonedElement = /** @type {HTMLElement} */ (inertDocument.importNode(element, true));
+    clonedElement.querySelectorAll("br").forEach((lineBreakElement) => {
+        lineBreakElement.replaceWith(inertDocument.createTextNode(SINGLE_NEWLINE));
+    });
+    const serializedTextContent = clonedElement.textContent || "";
+    return normalizeEditorText(serializedTextContent);
+}
+
+/**
  * Determines whether text is empty or contains only newline characters once normalized.
  * @param {string} normalizedText Text that has already passed through normalizeEditorText.
  * @returns {boolean} True when the text contains no visible characters.
@@ -267,7 +282,7 @@ export class InputPanel {
 
             if (childNode instanceof HTMLElement) {
                 const element = childNode;
-                const normalizedInnerText = normalizeEditorText(element.innerText);
+                const normalizedInnerText = serializeElementTextWithSoftBreaks(element);
                 const trimmedInnerText = normalizedInnerText.replace(
                     TRAILING_NEWLINE_PATTERN,
                     ""
@@ -291,13 +306,7 @@ export class InputPanel {
 
             const segmentText = /** @type {string} */ (segment);
             if (hasWrittenText) {
-                if (pendingSeparatorCount === 0) {
-                    normalizedPlaceholderText += DOUBLE_NEWLINE;
-                } else if (pendingSeparatorCount === 1) {
-                    normalizedPlaceholderText += SINGLE_NEWLINE;
-                } else {
-                    normalizedPlaceholderText += DOUBLE_NEWLINE;
-                }
+                normalizedPlaceholderText += DOUBLE_NEWLINE;
             }
             normalizedPlaceholderText += segmentText;
             hasWrittenText = true;

--- a/tests/inputPanel.test.js
+++ b/tests/inputPanel.test.js
@@ -24,10 +24,16 @@ const PARAGRAPH_TEXT_CONTENT = Object.freeze({
     inlineLinkTrailingText: " enriched paragraph content."
 });
 
+const SOFT_BREAK_TEXT_CONTENT = Object.freeze({
+    firstLine: "Soft line breaks remain within paragraphs.",
+    secondLine: "Soft line breaks should not create new paragraphs."
+});
+
 const EXPECTED_SNAPSHOT_TEXT = Object.freeze({
     sequentialParagraphs: "Paragraph #1.\n\nParagraph #2.\n\nParagraph #3.",
     inlineEmphasis: "Intro with emphasis highlighted conclusion.",
-    mixedInlineElements: "Leading strong text and trailing content.\n\nLink enriched paragraph content."
+    mixedInlineElements: "Leading strong text and trailing content.\n\nLink enriched paragraph content.",
+    softLineBreakParagraph: `${SOFT_BREAK_TEXT_CONTENT.firstLine}\n${SOFT_BREAK_TEXT_CONTENT.secondLine}`
 });
 
 const INLINE_ELEMENT_TEXT = Object.freeze({
@@ -43,7 +49,7 @@ const INLINE_ELEMENT_URLS = Object.freeze({
 const EDITOR_SEPARATOR_REGRESSION_TEXT = Object.freeze({
     firstParagraph: "Puppeteer ensures reliable browser coverage.",
     secondParagraph: "Browser automation validates paragraph counts.",
-    expectedLength: 91
+    expectedLength: 92
 });
 
 /**
@@ -131,8 +137,8 @@ const DOCUMENT_CASES = [
         ]
     },
     {
-        name: "treats spacer divs as single newline separators",
-        expectedText: `${EDITOR_SEPARATOR_REGRESSION_TEXT.firstParagraph}\n${EDITOR_SEPARATOR_REGRESSION_TEXT.secondParagraph}`,
+        name: "expands spacer divs to paragraph separators",
+        expectedText: `${EDITOR_SEPARATOR_REGRESSION_TEXT.firstParagraph}\n\n${EDITOR_SEPARATOR_REGRESSION_TEXT.secondParagraph}`,
         expectedLength: EDITOR_SEPARATOR_REGRESSION_TEXT.expectedLength,
         builderSteps: [
             /**
@@ -150,6 +156,23 @@ const DOCUMENT_CASES = [
             (targetEditorElement) => {
                 appendParagraphWithChildren(targetEditorElement, [
                     document.createTextNode(EDITOR_SEPARATOR_REGRESSION_TEXT.secondParagraph)
+                ]);
+            },
+            appendEmptyParagraph
+        ]
+    },
+    {
+        name: "preserves soft line breaks within paragraph boundaries",
+        expectedText: EXPECTED_SNAPSHOT_TEXT.softLineBreakParagraph,
+        builderSteps: [
+            /**
+             * @param {HTMLDivElement} targetEditorElement
+             */
+            (targetEditorElement) => {
+                appendParagraphWithChildren(targetEditorElement, [
+                    document.createTextNode(SOFT_BREAK_TEXT_CONTENT.firstLine),
+                    document.createElement("br"),
+                    document.createTextNode(SOFT_BREAK_TEXT_CONTENT.secondLine)
                 ]);
             },
             appendEmptyParagraph


### PR DESCRIPTION
## Summary
- ensure InputPanel serializes any pending spacer separators as paragraph breaks
- treat inline <br> elements as soft line breaks when deriving snapshot text
- update InputPanel tests for spacer div spacing and cover Shift+Enter soft line breaks

## Testing
- npm run test:headless
- npm run test:browser *(fails: Puppeteer could not launch because libatk-1.0.so.0 is missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d71ea6ac0c8327b957716cc00a9ca9