### PR TITLE
chore(social_threader): ensure gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,10 @@ shelf/
 *.iml
 node_modules/
 test-results/
+# Managed by gix gitignore workflow
+.env
+.env.*
+.DS_Store
+qodana.yaml
+tools/
+bin/


### PR DESCRIPTION
Ensure `.gitignore` contains the standard secrets/tooling entries (.env, tools/, bin/).