### PR TITLE
gix/migrate-to-local-android-app-bundle-build-and-publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ node_modules/
 configs/AuthKey_*.p8
 configs/*service-account*.json
 configs/google-play*.json
+configs/*keystore*.properties
+configs/*upload-key*.jks
+mobile/dist/
 test-results/
 # Managed by gix gitignore workflow
 .env

--- a/Makefile
+++ b/Makefile
@@ -3,20 +3,24 @@ MOBILE_NPM ?= npm
 MOBILE_EAS ?= npx eas-cli
 MOBILE_BUILD_PROFILE ?= production
 MOBILE_IOS_BUILD_PROFILE ?= $(MOBILE_BUILD_PROFILE)
-MOBILE_ANDROID_BUILD_PROFILE ?= $(MOBILE_BUILD_PROFILE)
 MOBILE_BUILD_ARGS ?=
 MOBILE_IOS_BUILD_ARGS ?=
-MOBILE_ANDROID_BUILD_ARGS ?=
 MOBILE_SUBMIT_ARGS ?=
 MOBILE_IOS_SUBMIT_ARGS ?=
-MOBILE_ANDROID_SUBMIT_ARGS ?=
+MOBILE_ANDROID_BUILD_DIR ?= /tmp/social-threader-mobile-android-aab
+MOBILE_ANDROID_VERSION_CODE ?= local
+MOBILE_ANDROID_BUNDLE_ARGS ?=
+MOBILE_ANDROID_PUBLISH_ARGS ?=
+MOBILE_ANDROID_BUNDLE_SCRIPT := $(MOBILE_DIR)/scripts/build-android-bundle.mjs
+MOBILE_ANDROID_PUBLISH_SCRIPT := $(MOBILE_DIR)/scripts/publish-android-play.mjs
 MOBILE_PORT ?= 8081
 MOBILE_EXPECT ?= /usr/bin/expect
 ANDROID_SDK_ROOT ?= $(HOME)/Library/Android/sdk
 ANDROID_HOME ?= $(ANDROID_SDK_ROOT)
+ANDROID_STUDIO_JAVA_HOME ?= /Applications/Android Studio.app/Contents/jbr/Contents/Home
 ANDROID_TOOL_PATH := $(ANDROID_SDK_ROOT)/emulator:$(ANDROID_SDK_ROOT)/platform-tools:$(ANDROID_SDK_ROOT)/cmdline-tools/latest/bin:$(ANDROID_SDK_ROOT)/tools/bin
 
-.PHONY: test ci mobile-install mobile-check run-ios run-android build-ios build-android submit-ios submit-android
+.PHONY: test ci mobile-install mobile-check run-ios run-android build-ios build-android mobile-android-bundle submit-ios submit-android
 
 test:
 	npm test
@@ -40,11 +44,15 @@ run-android: mobile-install
 build-ios: mobile-check
 	@cd "$(MOBILE_DIR)" && EAS_BUILD_PROFILE="$(MOBILE_IOS_BUILD_PROFILE)" $(MOBILE_EAS) build --platform ios --profile "$(MOBILE_IOS_BUILD_PROFILE)" $(MOBILE_BUILD_ARGS) $(MOBILE_IOS_BUILD_ARGS)
 
-build-android: mobile-check
-	@cd "$(MOBILE_DIR)" && EAS_BUILD_PROFILE="$(MOBILE_ANDROID_BUILD_PROFILE)" $(MOBILE_EAS) build --platform android --profile "$(MOBILE_ANDROID_BUILD_PROFILE)" $(MOBILE_BUILD_ARGS) $(MOBILE_ANDROID_BUILD_ARGS)
+build-android: mobile-android-bundle
+
+mobile-android-bundle: mobile-check
+	@echo "==> [mobile-android-bundle] Building signed Social Threader Android App Bundle"
+	@ANDROID_HOME="$(ANDROID_HOME)" ANDROID_SDK_ROOT="$(ANDROID_SDK_ROOT)" ANDROID_STUDIO_JAVA_HOME="$(ANDROID_STUDIO_JAVA_HOME)" node "$(MOBILE_ANDROID_BUNDLE_SCRIPT)" --mobile-dir "$(MOBILE_DIR)" --build-dir "$(MOBILE_ANDROID_BUILD_DIR)" --android-sdk-root "$(ANDROID_SDK_ROOT)" --version-code "$(MOBILE_ANDROID_VERSION_CODE)" $(MOBILE_ANDROID_BUNDLE_ARGS)
 
 submit-ios: mobile-check
 	@cd "$(MOBILE_DIR)" && $(MOBILE_EAS) submit --platform ios --latest $(MOBILE_SUBMIT_ARGS) $(MOBILE_IOS_SUBMIT_ARGS)
 
-submit-android: mobile-check
-	@cd "$(MOBILE_DIR)" && $(MOBILE_EAS) submit --platform android --latest $(MOBILE_SUBMIT_ARGS) $(MOBILE_ANDROID_SUBMIT_ARGS)
+submit-android: mobile-android-bundle
+	@echo "==> [submit-android] Submitting Social Threader Android App Bundle to Google Play"
+	@node "$(MOBILE_ANDROID_PUBLISH_SCRIPT)" --mobile-dir "$(MOBILE_DIR)" $(MOBILE_ANDROID_PUBLISH_ARGS)

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -27,7 +27,7 @@ make submit-ios
 make submit-android
 ```
 
-`make build-ios` and `make build-android` use the `production` EAS profile. Android production builds emit an App Bundle.
+`make build-ios` uses the `production` EAS profile. `make build-android` follows the Kamu-style local Google Play path: Expo prebuilds Android in a temporary directory, Gradle creates a signed App Bundle, and the script writes a checked build manifest beside the `.aab`.
 
 `make run-ios` starts Metro through `scripts/ios-run.mjs`, selects an available Expo port before startup, and then runs Expo through `scripts/expo-run.expect` so known Expo prompts do not block local startup: Expo Go version upgrades are accepted automatically, while unexpected port changes are rejected.
 
@@ -35,7 +35,7 @@ make submit-android
 
 ## Store Publishing Checklist
 
-Keep App Store Connect keys, Google service account JSON files, and other store credentials out of git. Local files matching `configs/AuthKey_*.p8`, `configs/*service-account*.json`, and `configs/google-play*.json` are ignored by the repository.
+Keep App Store Connect keys, Google service account JSON files, Android upload keystores, and other store credentials out of git. Local files matching `configs/AuthKey_*.p8`, `configs/*service-account*.json`, `configs/google-play*.json`, `configs/*keystore*.properties`, and `configs/*upload-key*.jks` are ignored by the repository.
 
 ### Shared preflight
 
@@ -73,8 +73,15 @@ make submit-ios MOBILE_IOS_SUBMIT_ARGS="--non-interactive --wait"
 
 ### Google Play
 
-- [ ] Create or confirm a Google Play service account with Android Publisher access for this app.
-- [ ] Add the service account key to EAS credentials with `eas credentials --platform android`, or configure `serviceAccountKeyPath` in the Android submit profile using a local ignored JSON file.
+- [ ] Create or confirm a Google Play app with package name `com.mprlab.socialthreader`.
+- [ ] Create an Android upload keystore and keep it outside git. The local builder defaults to `~/.local/share/social_threader/android-upload/keystore.properties` and `~/.local/share/social_threader/android-upload/socialthreader-upload-key.jks`.
+- [ ] Add the Play upload-key SHA-256 and Google Cloud quota project to `mobile/android-release-identity.json`, using `mobile/android-release-identity.example.json` as the template.
+- [ ] Configure Google Application Default Credentials with Android Publisher access:
+
+```sh
+gcloud auth application-default login --scopes=https://www.googleapis.com/auth/androidpublisher,https://www.googleapis.com/auth/cloud-platform
+```
+
 - [ ] Confirm the Play Console setup is complete: app content, Data safety, privacy policy, content rating, target audience, ads declaration, and testing track.
 - [ ] Build the Android App Bundle:
 
@@ -82,10 +89,11 @@ make submit-ios MOBILE_IOS_SUBMIT_ARGS="--non-interactive --wait"
 make build-android
 ```
 
-- [ ] After the EAS Android build finishes, submit it first to internal testing:
+- [ ] The first Google Play upload may need to be performed manually in Play Console. Upload `mobile/dist/social-threader-<version>-android-release.aab`, then verify the release on the internal testing track.
+- [ ] For subsequent automated internal testing uploads, submit through the Google Play Android Publisher API:
 
 ```sh
-make submit-android MOBILE_ANDROID_SUBMIT_ARGS="--non-interactive --wait"
+make submit-android
 ```
 
 - [ ] In Play Console, verify the internal-test release, then promote to production after testing.

--- a/mobile/android-release-identity.example.json
+++ b/mobile/android-release-identity.example.json
@@ -1,0 +1,8 @@
+{
+  "schema": "social-threader.mobile-android-release-identity.v1",
+  "googleCloudProjectId": "YOUR_GOOGLE_CLOUD_PROJECT_ID",
+  "packageName": "com.mprlab.socialthreader",
+  "uploadKey": {
+    "sha256": "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99"
+  }
+}

--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -14,10 +14,7 @@
       }
     },
     "production": {
-      "distribution": "store",
-      "android": {
-        "buildType": "app-bundle"
-      }
+      "distribution": "store"
     }
   },
   "submit": {

--- a/mobile/scripts/build-android-bundle.mjs
+++ b/mobile/scripts/build-android-bundle.mjs
@@ -1,0 +1,992 @@
+#!/usr/bin/env node
+// @ts-check
+/// <reference types="node" />
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(SCRIPT_DIR, "../..");
+const DEFAULT_MOBILE_DIR = path.join(REPO_ROOT, "mobile");
+const DEFAULT_BUILD_DIR = path.join(os.tmpdir(), "social-threader-mobile-android-aab");
+const DEFAULT_CREDENTIAL_DIR = path.join(os.homedir(), ".local", "share", "social_threader", "android-upload");
+const DEFAULT_KEYSTORE_PROPERTIES = path.join(DEFAULT_CREDENTIAL_DIR, "keystore.properties");
+const DEFAULT_KEYSTORE = path.join(DEFAULT_CREDENTIAL_DIR, "socialthreader-upload-key.jks");
+const DEFAULT_ANDROID_SDK_ROOT = path.join(os.homedir(), "Library", "Android", "sdk");
+const BUNDLE_SCHEMA = "social-threader.mobile-android-bundle.v1";
+const ANDROID_PUBLISHER_API_BASE = "https://androidpublisher.googleapis.com/androidpublisher/v3/applications";
+const ANDROID_PUBLISHER_SCOPE = "https://www.googleapis.com/auth/androidpublisher";
+const SIGNING_ENV_PREFIX = "SOCIAL_THREADER_ANDROID_UPLOAD";
+
+class BuildError extends Error {
+  /**
+   * @param {string} message
+   */
+  constructor(message) {
+    super(message);
+    this.name = "BuildError";
+  }
+}
+
+try {
+  const args = parseArgs(process.argv.slice(2));
+  const metadata = buildAndroidBundle(args);
+  process.stdout.write(`${JSON.stringify(metadata, null, 2)}\n`);
+} catch (error) {
+  if (error instanceof BuildError) {
+    process.stderr.write(`mobile android bundle failed: ${error.message}\n`);
+    process.exit(2);
+  }
+  throw error;
+}
+
+/**
+ * @typedef {{
+ *   mobileDir: string;
+ *   buildDir: string;
+ *   output: string;
+ *   versionCode: string;
+ *   keystoreProperties: string;
+ *   keystore: string;
+ *   javaHome: string;
+ *   androidSdkRoot: string;
+ *   quotaProject: string;
+ *   keepBuildDir: boolean;
+ * }} BundleArgs
+ */
+
+/**
+ * @param {string[]} argv
+ * @returns {BundleArgs}
+ */
+function parseArgs(argv) {
+  const options = new Map();
+  const flags = new Set();
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--keep-build-dir") {
+      flags.add("keep-build-dir");
+      continue;
+    }
+    if (!token.startsWith("--")) {
+      throw new BuildError(`unexpected positional argument: ${token}`);
+    }
+    const equalsIndex = token.indexOf("=");
+    if (equalsIndex > 0) {
+      options.set(token.slice(2, equalsIndex), token.slice(equalsIndex + 1));
+      continue;
+    }
+    const optionName = token.slice(2);
+    const optionValue = argv[index + 1];
+    if (!optionValue || optionValue.startsWith("--")) {
+      throw new BuildError(`missing value for --${optionName}`);
+    }
+    options.set(optionName, optionValue);
+    index += 1;
+  }
+
+  return {
+    mobileDir: resolvePath(options.get("mobile-dir") || DEFAULT_MOBILE_DIR),
+    buildDir: resolvePath(options.get("build-dir") || DEFAULT_BUILD_DIR),
+    output: options.has("output") ? resolvePath(options.get("output") || "") : "",
+    versionCode: String(options.get("version-code") || process.env.SOCIAL_THREADER_ANDROID_VERSION_CODE || "local"),
+    keystoreProperties: resolvePath(
+      options.get("keystore-properties") ||
+        process.env.SOCIAL_THREADER_ANDROID_KEYSTORE_PROPERTIES ||
+        DEFAULT_KEYSTORE_PROPERTIES
+    ),
+    keystore: resolvePath(options.get("keystore") || process.env.SOCIAL_THREADER_ANDROID_UPLOAD_STORE_FILE || DEFAULT_KEYSTORE),
+    javaHome: resolveJavaHome(options.get("java-home") || process.env.JAVA_HOME || ""),
+    androidSdkRoot: resolvePath(options.get("android-sdk-root") || process.env.ANDROID_SDK_ROOT || process.env.ANDROID_HOME || DEFAULT_ANDROID_SDK_ROOT),
+    quotaProject: String(options.get("quota-project") || process.env.GOOGLE_CLOUD_QUOTA_PROJECT || process.env.GCLOUD_QUOTA_PROJECT || ""),
+    keepBuildDir: flags.has("keep-build-dir")
+  };
+}
+
+/**
+ * @param {BundleArgs} args
+ * @returns {Record<string, unknown>}
+ */
+function buildAndroidBundle(args) {
+  const appConfig = readAppConfig(args.mobileDir);
+  const versionCodeResolution = resolveVersionCode(args.versionCode, appConfig, args.quotaProject);
+  const signing = readSigningProperties(args.keystoreProperties, args.keystore);
+  const expectedUploadKeySha256 = readExpectedUploadKeySha256(args.mobileDir);
+  const uploadKeySha256 = verifyUploadKeyFingerprint(signing, args.javaHome, expectedUploadKeySha256);
+
+  requireFile(path.join(args.mobileDir, "package.json"), "mobile package.json");
+  requireFile(path.join(args.mobileDir, "package-lock.json"), "mobile package-lock.json");
+  requireDirectory(args.androidSdkRoot, "Android SDK root");
+  requireExecutable(path.join(args.javaHome, "bin", "java"), "java");
+  requireExecutable(path.join(args.javaHome, "bin", "jarsigner"), "jarsigner");
+  requireExecutable(path.join(args.javaHome, "bin", "keytool"), "keytool");
+  requireExecutable(which("npm"), "npm");
+  requireExecutable(which("bundletool"), "bundletool");
+  requireExecutable(which("unzip"), "unzip");
+
+  if (args.buildDir === "/" || args.buildDir === os.tmpdir()) {
+    throw new BuildError(`unsafe build directory: ${args.buildDir}`);
+  }
+
+  fs.rmSync(args.buildDir, { recursive: true, force: true });
+  const buildMobileDir = path.join(args.buildDir, "mobile");
+  copyMobileProject(args.mobileDir, buildMobileDir);
+  patchAndroidVersionCodeInAppJson(buildMobileDir, versionCodeResolution.versionCode);
+
+  const env = buildEnvironment(args.javaHome, args.androidSdkRoot);
+  run(["npm", "ci"], { cwd: buildMobileDir, env });
+  run(["npx", "--no-install", "expo", "prebuild", "--platform", "android", "--no-install"], { cwd: buildMobileDir, env });
+  writeLocalProperties(path.join(buildMobileDir, "android", "local.properties"), args.androidSdkRoot);
+  enableReleaseMinification(path.join(buildMobileDir, "android", "gradle.properties"));
+  patchReleaseSigning(path.join(buildMobileDir, "android", "app", "build.gradle"));
+
+  /** @type {NodeJS.ProcessEnv} */
+  const gradleEnv = { ...env };
+  gradleEnv.NODE_ENV = "production";
+  gradleEnv[`${SIGNING_ENV_PREFIX}_STORE_FILE`] = signing.storeFile;
+  gradleEnv[`${SIGNING_ENV_PREFIX}_STORE_PASSWORD`] = signing.storePassword;
+  gradleEnv[`${SIGNING_ENV_PREFIX}_KEY_ALIAS`] = signing.keyAlias;
+  gradleEnv[`${SIGNING_ENV_PREFIX}_KEY_PASSWORD`] = signing.keyPassword;
+  run(["./gradlew", "--no-daemon", "bundleRelease"], { cwd: path.join(buildMobileDir, "android"), env: gradleEnv });
+
+  const generatedBundle = path.join(buildMobileDir, "android", "app", "build", "outputs", "bundle", "release", "app-release.aab");
+  requireFile(generatedBundle, "generated release app bundle");
+  const outputPath = args.output || defaultOutputPath(args.mobileDir, appConfig.version);
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.copyFileSync(generatedBundle, outputPath);
+  const mappingOutputPath = copyDeobfuscationFile(buildMobileDir, outputPath);
+  const validation = validateBundle(outputPath, args.javaHome, uploadKeySha256);
+
+  if (validation.packageName !== appConfig.packageName) {
+    throw new BuildError(`generated bundle package ${validation.packageName} does not match app.json ${appConfig.packageName}`);
+  }
+  if (validation.versionName !== appConfig.version) {
+    throw new BuildError(`generated bundle versionName ${validation.versionName} does not match app.json ${appConfig.version}`);
+  }
+  if (validation.versionCode !== versionCodeResolution.versionCode) {
+    throw new BuildError(`generated bundle versionCode ${validation.versionCode} does not match resolved versionCode ${versionCodeResolution.versionCode}`);
+  }
+
+  if (!args.keepBuildDir) {
+    fs.rmSync(args.buildDir, { recursive: true, force: true });
+  }
+
+  /** @type {Record<string, unknown>} */
+  const metadata = {
+    schema: BUNDLE_SCHEMA,
+    status: "passed",
+    androidPackage: appConfig.packageName,
+    versionName: validation.versionName,
+    versionCode: validation.versionCode,
+    sourceVersionCode: appConfig.versionCode,
+    versionCodeSource: versionCodeResolution.source,
+    versionCodePolicy: versionCodeResolution.policy,
+    googlePlayMaxVersionCode: versionCodeResolution.googlePlayMaxVersionCode,
+    output: outputPath,
+    sha256: sha256File(outputPath),
+    sizeBytes: fs.statSync(outputPath).size,
+    deobfuscationFile: mappingOutputPath,
+    deobfuscationSha256: sha256File(mappingOutputPath),
+    keystore: signing.storeFile,
+    uploadKeySha256,
+    signerOwner: validation.signerOwner,
+    signerSha256: validation.signerSha256,
+    zipIntegrity: "passed",
+    jarSignature: "passed",
+    releaseSigner: "passed",
+    bundletoolValidated: validation.bundletoolValidated,
+    r8Minification: "enabled",
+    resourceShrinking: "disabled"
+  };
+  metadata.buildManifest = writeBuildManifest(outputPath, metadata);
+  return metadata;
+}
+
+/**
+ * @param {string} mobileDir
+ * @returns {{ version: string; versionCode: number; packageName: string }}
+ */
+function readAppConfig(mobileDir) {
+  const appJsonPath = path.join(mobileDir, "app.json");
+  requireFile(appJsonPath, "Expo app.json");
+  const appJson = JSON.parse(fs.readFileSync(appJsonPath, "utf8"));
+  const expoConfig = appJson.expo || {};
+  const androidConfig = expoConfig.android || {};
+  return {
+    version: requireString(expoConfig.version, `expo.version in ${appJsonPath}`),
+    versionCode: requirePositiveInteger(androidConfig.versionCode, `expo.android.versionCode in ${appJsonPath}`),
+    packageName: requireString(androidConfig.package, `expo.android.package in ${appJsonPath}`)
+  };
+}
+
+/**
+ * @param {string} requested
+ * @param {{ versionCode: number; packageName: string }} appConfig
+ * @param {string} quotaProject
+ * @returns {{ versionCode: number; source: string; policy: string; googlePlayMaxVersionCode: number | null }}
+ */
+function resolveVersionCode(requested, appConfig, quotaProject) {
+  const normalizedValue = requested.trim().toLowerCase();
+  if (normalizedValue === "local") {
+    return {
+      versionCode: appConfig.versionCode,
+      source: "local_app_json",
+      policy: "expo.android.versionCode",
+      googlePlayMaxVersionCode: null
+    };
+  }
+  if (normalizedValue === "auto") {
+    if (!quotaProject) {
+      throw new BuildError("--version-code auto requires --quota-project, GOOGLE_CLOUD_QUOTA_PROJECT, or GCLOUD_QUOTA_PROJECT");
+    }
+    const googlePlayMaxVersionCode = fetchGooglePlayMaxVersionCode(appConfig.packageName, quotaProject);
+    return {
+      versionCode: Math.max(appConfig.versionCode, googlePlayMaxVersionCode + 1),
+      source: "google_play",
+      policy: "max(expo.android.versionCode, google_play_max_version_code + 1)",
+      googlePlayMaxVersionCode
+    };
+  }
+  if (!/^[1-9][0-9]*$/.test(normalizedValue)) {
+    throw new BuildError("--version-code must be local, auto, or a positive integer");
+  }
+  const versionCode = Number(normalizedValue);
+  if (versionCode < appConfig.versionCode) {
+    throw new BuildError(`explicit Android versionCode ${versionCode} must be at least mobile/app.json ${appConfig.versionCode}`);
+  }
+  return {
+    versionCode,
+    source: "operator_override",
+    policy: "explicit --version-code",
+    googlePlayMaxVersionCode: null
+  };
+}
+
+/**
+ * @param {string} packageName
+ * @param {string} quotaProject
+ * @returns {number}
+ */
+function fetchGooglePlayMaxVersionCode(packageName, quotaProject) {
+  const token = accessTokenFromApplicationDefaultCredentials();
+  const headers = googleAuthHeaders(token, quotaProject);
+  const edit = requestJsonSync({
+    method: "POST",
+    url: publisherUrl(packageName, "edits"),
+    headers,
+    label: "create Android Publisher edit"
+  });
+  const editId = requireString(edit.id, "edit id");
+  const versionCodes = [];
+  try {
+    for (const resource of ["bundles", "apks"]) {
+      const payload = requestJsonSync({
+        method: "GET",
+        url: publisherUrl(packageName, `edits/${encodeURIComponent(editId)}/${resource}`),
+        headers,
+        label: `list Android Publisher ${resource}`
+      });
+      versionCodes.push(...extractVersionCodes(payload));
+    }
+    const tracks = requestJsonSync({
+      method: "GET",
+      url: publisherUrl(packageName, `edits/${encodeURIComponent(editId)}/tracks`),
+      headers,
+      label: "list Android Publisher tracks"
+    });
+    versionCodes.push(...extractVersionCodes(tracks));
+  } finally {
+    requestJsonSync({
+      method: "DELETE",
+      url: publisherUrl(packageName, `edits/${encodeURIComponent(editId)}`),
+      headers,
+      label: "delete Android Publisher edit",
+      allowFailure: true
+    });
+  }
+  return versionCodes.length ? Math.max(...versionCodes) : 0;
+}
+
+/**
+ * @param {string} propertiesPath
+ * @param {string} keystorePath
+ * @returns {{ storeFile: string; storePassword: string; keyAlias: string; keyPassword: string }}
+ */
+function readSigningProperties(propertiesPath, keystorePath) {
+  requireFile(propertiesPath, "Android upload signing properties");
+  const properties = readProperties(propertiesPath);
+  const storeFile = resolveKeystorePath(properties.storeFile || keystorePath, propertiesPath);
+  const keyAlias = requireProperty(properties, "keyAlias", propertiesPath);
+  const storePassword = requireProperty(properties, "storePassword", propertiesPath);
+  const keyPassword = requireProperty(properties, "keyPassword", propertiesPath);
+  requireFile(storeFile, "Android upload keystore");
+  return { storeFile, storePassword, keyAlias, keyPassword };
+}
+
+/**
+ * @param {string} mobileDir
+ * @returns {string}
+ */
+function readExpectedUploadKeySha256(mobileDir) {
+  const identityPath = path.join(mobileDir, "android-release-identity.json");
+  if (!fs.existsSync(identityPath)) {
+    return "";
+  }
+  const identity = JSON.parse(fs.readFileSync(identityPath, "utf8"));
+  return normalizeSha256Fingerprint(String(identity.uploadKey?.sha256 || ""));
+}
+
+/**
+ * @param {{ storeFile: string; storePassword: string; keyAlias: string }} signing
+ * @param {string} javaHome
+ * @param {string} expectedSha256
+ * @returns {string}
+ */
+function verifyUploadKeyFingerprint(signing, javaHome, expectedSha256) {
+  const certificateOutput = runAndRead(
+    [
+      path.join(javaHome, "bin", "keytool"),
+      "-list",
+      "-v",
+      "-keystore",
+      signing.storeFile,
+      "-storepass",
+      signing.storePassword,
+      "-alias",
+      signing.keyAlias
+    ],
+    {
+      label: `${path.join(javaHome, "bin", "keytool")} -list -v -keystore ${signing.storeFile} -alias ${signing.keyAlias}`
+    }
+  );
+  const actualSha256 = certificateSha256FromOutput(certificateOutput, "Android upload keystore certificate");
+  if (expectedSha256 && actualSha256 !== expectedSha256) {
+    throw new BuildError(`Android upload key SHA-256 ${actualSha256} does not match release identity ${expectedSha256}`);
+  }
+  return actualSha256;
+}
+
+/**
+ * @param {string} source
+ * @param {string} destination
+ */
+function copyMobileProject(source, destination) {
+  fs.mkdirSync(destination, { recursive: true });
+  const ignoredNames = new Set(["node_modules", ".expo", "dist", "android", "ios"]);
+  for (const entry of fs.readdirSync(source, { withFileTypes: true })) {
+    if (ignoredNames.has(entry.name)) {
+      continue;
+    }
+    fs.cpSync(path.join(source, entry.name), path.join(destination, entry.name), { recursive: true, verbatimSymlinks: true });
+  }
+}
+
+/**
+ * @param {string} mobileDir
+ * @param {number} versionCode
+ */
+function patchAndroidVersionCodeInAppJson(mobileDir, versionCode) {
+  const appJsonPath = path.join(mobileDir, "app.json");
+  const payload = JSON.parse(fs.readFileSync(appJsonPath, "utf8"));
+  payload.expo = payload.expo || {};
+  payload.expo.android = payload.expo.android || {};
+  payload.expo.android.versionCode = versionCode;
+  fs.writeFileSync(appJsonPath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+}
+
+/**
+ * @param {string} javaHome
+ * @param {string} androidSdkRoot
+ * @returns {NodeJS.ProcessEnv}
+ */
+function buildEnvironment(javaHome, androidSdkRoot) {
+  return {
+    ...process.env,
+    CI: "1",
+    EXPO_NO_TELEMETRY: "1",
+    JAVA_HOME: javaHome,
+    ANDROID_HOME: androidSdkRoot,
+    ANDROID_SDK_ROOT: androidSdkRoot,
+    PATH: [
+      path.join(javaHome, "bin"),
+      path.join(androidSdkRoot, "platform-tools"),
+      path.join(androidSdkRoot, "cmdline-tools", "latest", "bin"),
+      process.env.PATH || ""
+    ]
+      .filter(Boolean)
+      .join(path.delimiter)
+  };
+}
+
+/**
+ * @param {string} localPropertiesPath
+ * @param {string} androidSdkRoot
+ */
+function writeLocalProperties(localPropertiesPath, androidSdkRoot) {
+  fs.mkdirSync(path.dirname(localPropertiesPath), { recursive: true });
+  fs.writeFileSync(localPropertiesPath, `sdk.dir=${androidSdkRoot}\n`, "utf8");
+}
+
+/**
+ * @param {string} gradlePropertiesPath
+ */
+function enableReleaseMinification(gradlePropertiesPath) {
+  const properties = readProperties(gradlePropertiesPath);
+  properties["android.enableMinifyInReleaseBuilds"] = "true";
+  properties["android.enableShrinkResourcesInReleaseBuilds"] = "false";
+  writeProperties(gradlePropertiesPath, properties);
+}
+
+/**
+ * @param {string} buildGradlePath
+ */
+function patchReleaseSigning(buildGradlePath) {
+  let text = fs.readFileSync(buildGradlePath, "utf8");
+  const projectRootLine = "def projectRoot = rootDir.getAbsoluteFile().getParentFile().getAbsolutePath()";
+  const signingDefinitions = `
+def uploadStoreFile = System.getenv("${SIGNING_ENV_PREFIX}_STORE_FILE") ?: ""
+def uploadStorePassword = System.getenv("${SIGNING_ENV_PREFIX}_STORE_PASSWORD") ?: ""
+def uploadKeyAlias = System.getenv("${SIGNING_ENV_PREFIX}_KEY_ALIAS") ?: ""
+def uploadKeyPassword = System.getenv("${SIGNING_ENV_PREFIX}_KEY_PASSWORD") ?: ""
+if (!uploadStoreFile || !uploadStorePassword || !uploadKeyAlias || !uploadKeyPassword) {
+    throw new GradleException("Social Threader release signing requires ${SIGNING_ENV_PREFIX}_* environment variables")
+}
+`.trimEnd();
+  if (!text.includes(signingDefinitions)) {
+    text = text.replace(projectRootLine, `${projectRootLine}\n${signingDefinitions}`);
+  }
+
+  const debugSigningBlock = `    signingConfigs {
+        debug {
+            storeFile file('debug.keystore')
+            storePassword 'android'
+            keyAlias 'androiddebugkey'
+            keyPassword 'android'
+        }
+    }`;
+  const releaseSigningBlock = `    signingConfigs {
+        debug {
+            storeFile file('debug.keystore')
+            storePassword 'android'
+            keyAlias 'androiddebugkey'
+            keyPassword 'android'
+        }
+        release {
+            storeFile file(uploadStoreFile)
+            storePassword uploadStorePassword
+            keyAlias uploadKeyAlias
+            keyPassword uploadKeyPassword
+        }
+    }`;
+  if (!text.includes(releaseSigningBlock)) {
+    if (!text.includes(debugSigningBlock)) {
+      throw new BuildError(`could not find generated signingConfigs block in ${buildGradlePath}`);
+    }
+    text = text.replace(debugSigningBlock, releaseSigningBlock);
+  }
+
+  const debugReleaseLine = "            signingConfig signingConfigs.debug";
+  const uploadReleaseLine = "            signingConfig signingConfigs.release";
+  const buildTypesIndex = text.indexOf("    buildTypes {");
+  if (buildTypesIndex === -1) {
+    throw new BuildError(`could not find buildTypes block in ${buildGradlePath}`);
+  }
+  const releaseIndex = text.indexOf("        release {", buildTypesIndex);
+  if (releaseIndex === -1) {
+    throw new BuildError(`could not find release buildType in ${buildGradlePath}`);
+  }
+  const releaseEnd = findGradleBlockEnd(text, releaseIndex);
+  let releaseBlock = text.slice(releaseIndex, releaseEnd);
+  if (!releaseBlock.includes(uploadReleaseLine)) {
+    if (!releaseBlock.includes(debugReleaseLine)) {
+      throw new BuildError(`could not find release signingConfig line in ${buildGradlePath}`);
+    }
+    releaseBlock = releaseBlock.replace(debugReleaseLine, uploadReleaseLine);
+    text = `${text.slice(0, releaseIndex)}${releaseBlock}${text.slice(releaseEnd)}`;
+  }
+  fs.writeFileSync(buildGradlePath, text, "utf8");
+}
+
+/**
+ * @param {string} text
+ * @param {number} blockStart
+ * @returns {number}
+ */
+function findGradleBlockEnd(text, blockStart) {
+  const braceStart = text.indexOf("{", blockStart);
+  if (braceStart === -1) {
+    throw new BuildError("could not find Gradle block opening brace");
+  }
+  let depth = 0;
+  for (let index = braceStart; index < text.length; index += 1) {
+    if (text[index] === "{") {
+      depth += 1;
+    } else if (text[index] === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return index + 1;
+      }
+    }
+  }
+  throw new BuildError("could not find Gradle block closing brace");
+}
+
+/**
+ * @param {string} buildMobileDir
+ * @param {string} outputPath
+ * @returns {string}
+ */
+function copyDeobfuscationFile(buildMobileDir, outputPath) {
+  const generatedMapping = path.join(buildMobileDir, "android", "app", "build", "outputs", "mapping", "release", "mapping.txt");
+  requireFile(generatedMapping, "R8 deobfuscation mapping file");
+  const mappingOutputPath = matchingOutputPath(outputPath, "-mapping.txt");
+  fs.copyFileSync(generatedMapping, mappingOutputPath);
+  return mappingOutputPath;
+}
+
+/**
+ * @param {string} bundlePath
+ * @param {string} javaHome
+ * @param {string} uploadKeySha256
+ * @returns {{ packageName: string; versionName: string; versionCode: number; signerOwner: string; signerSha256: string; bundletoolValidated: boolean }}
+ */
+function validateBundle(bundlePath, javaHome, uploadKeySha256) {
+  run(["unzip", "-tq", bundlePath], { quiet: true });
+  run([path.join(javaHome, "bin", "jarsigner"), "-verify", bundlePath], { quiet: true });
+  const certificateOutput = runAndRead([path.join(javaHome, "bin", "keytool"), "-printcert", "-jarfile", bundlePath], {
+    label: `${path.join(javaHome, "bin", "keytool")} -printcert -jarfile ${bundlePath}`
+  });
+  const signerOwner = ownerFromCertificateOutput(certificateOutput);
+  const signerSha256 = certificateSha256FromOutput(certificateOutput, "Android App Bundle signer");
+  if (signerSha256 !== uploadKeySha256) {
+    throw new BuildError(`Android App Bundle signer SHA-256 ${signerSha256} does not match upload key ${uploadKeySha256}`);
+  }
+  const bundletool = which("bundletool");
+  requireExecutable(bundletool, "bundletool");
+  run([bundletool, "validate", `--bundle=${bundlePath}`], { quiet: true });
+  return {
+    ...readBundleManifest(bundlePath, bundletool),
+    signerOwner,
+    signerSha256,
+    bundletoolValidated: true
+  };
+}
+
+/**
+ * @param {string} bundlePath
+ * @param {string} bundletool
+ * @returns {{ packageName: string; versionName: string; versionCode: number }}
+ */
+function readBundleManifest(bundlePath, bundletool) {
+  const packageName = runAndRead([bundletool, "dump", "manifest", `--bundle=${bundlePath}`, "--xpath=/manifest/@package"], {
+    label: "read generated bundle package"
+  }).trim();
+  const versionCodeRaw = runAndRead([bundletool, "dump", "manifest", `--bundle=${bundlePath}`, "--xpath=/manifest/@android:versionCode"], {
+    label: "read generated bundle versionCode"
+  }).trim();
+  const versionName = runAndRead([bundletool, "dump", "manifest", `--bundle=${bundlePath}`, "--xpath=/manifest/@android:versionName"], {
+    label: "read generated bundle versionName"
+  }).trim();
+  return {
+    packageName: requireString(packageName, "bundle package"),
+    versionName: requireString(versionName, "bundle versionName"),
+    versionCode: requirePositiveInteger(versionCodeRaw, "bundle versionCode")
+  };
+}
+
+/**
+ * @param {string} outputPath
+ * @param {Record<string, unknown>} metadata
+ * @returns {string}
+ */
+function writeBuildManifest(outputPath, metadata) {
+  const manifestPath = outputPath.replace(/\.aab$/, ".json");
+  const manifest = { ...metadata, buildManifest: manifestPath };
+  fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+  return manifestPath;
+}
+
+/**
+ * @param {{ method: string; url: string; headers: Record<string, string>; label: string; allowFailure?: boolean }} request
+ * @returns {Record<string, unknown>}
+ */
+function requestJsonSync(request) {
+  const curlArgs = ["-sS", "-X", request.method];
+  for (const [key, value] of Object.entries(request.headers)) {
+    curlArgs.push("-H", `${key}: ${value}`);
+  }
+  curlArgs.push(request.url);
+  const result = spawnSync("curl", curlArgs, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+  if (result.error || result.status !== 0) {
+    if (request.allowFailure) {
+      return {};
+    }
+    const detail = `${result.stdout || ""}${result.stderr || ""}`.trim();
+    throw new BuildError(`${request.label} failed${detail ? `: ${detail}` : ""}`);
+  }
+  const output = result.stdout.trim();
+  if (!output) {
+    return {};
+  }
+  const payload = JSON.parse(output);
+  if (payload && typeof payload === "object" && "error" in payload && !request.allowFailure) {
+    throw new BuildError(`${request.label} failed: ${JSON.stringify(payload.error)}`);
+  }
+  return payload && typeof payload === "object" ? payload : {};
+}
+
+/**
+ * @returns {string}
+ */
+function accessTokenFromApplicationDefaultCredentials() {
+  const result = spawnSync("gcloud", ["auth", "application-default", "print-access-token"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+  if (result.error) {
+    throw new BuildError(`could not run gcloud for ADC token: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    const detail = `${result.stdout || ""}${result.stderr || ""}`.trim();
+    throw new BuildError(
+      `could not read Google Application Default Credentials token with ${ANDROID_PUBLISHER_SCOPE}; ` +
+        `run gcloud auth application-default login --scopes=${ANDROID_PUBLISHER_SCOPE},https://www.googleapis.com/auth/cloud-platform` +
+        (detail ? `: ${detail}` : "")
+    );
+  }
+  return result.stdout.trim();
+}
+
+/**
+ * @param {string} token
+ * @param {string} quotaProject
+ * @returns {Record<string, string>}
+ */
+function googleAuthHeaders(token, quotaProject) {
+  const headers = { Authorization: `Bearer ${token}` };
+  if (quotaProject) {
+    headers["X-Goog-User-Project"] = quotaProject;
+  }
+  return headers;
+}
+
+/**
+ * @param {string} packageName
+ * @param {string} pathSuffix
+ * @returns {string}
+ */
+function publisherUrl(packageName, pathSuffix) {
+  return `${ANDROID_PUBLISHER_API_BASE}/${encodeURIComponent(packageName)}/${pathSuffix}`;
+}
+
+/**
+ * @param {unknown} payload
+ * @returns {number[]}
+ */
+function extractVersionCodes(payload) {
+  const codes = [];
+  const stack = [payload];
+  while (stack.length) {
+    const value = stack.pop();
+    if (Array.isArray(value)) {
+      stack.push(...value);
+      continue;
+    }
+    if (!value || typeof value !== "object") {
+      continue;
+    }
+    for (const [key, entry] of Object.entries(value)) {
+      if (key === "versionCode" || key === "versionCodes") {
+        const entries = Array.isArray(entry) ? entry : [entry];
+        for (const rawCode of entries) {
+          const numberValue = Number(rawCode);
+          if (Number.isInteger(numberValue) && numberValue > 0) {
+            codes.push(numberValue);
+          }
+        }
+      } else {
+        stack.push(entry);
+      }
+    }
+  }
+  return codes;
+}
+
+/**
+ * @param {string} rawPath
+ * @param {string} propertiesPath
+ * @returns {string}
+ */
+function resolveKeystorePath(rawPath, propertiesPath) {
+  const expandedPath = resolvePath(rawPath);
+  if (path.isAbsolute(expandedPath)) {
+    return expandedPath;
+  }
+  return path.resolve(path.dirname(propertiesPath), expandedPath);
+}
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function resolvePath(value) {
+  if (!value) {
+    return "";
+  }
+  if (value === "~") {
+    return os.homedir();
+  }
+  if (value.startsWith("~/")) {
+    return path.join(os.homedir(), value.slice(2));
+  }
+  return path.resolve(value);
+}
+
+/**
+ * @param {string} explicitJavaHome
+ * @returns {string}
+ */
+function resolveJavaHome(explicitJavaHome) {
+  const candidates = [
+    explicitJavaHome,
+    process.env.ANDROID_STUDIO_JAVA_HOME || "",
+    "/Applications/Android Studio.app/Contents/jbr/Contents/Home",
+    "/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home",
+    "/opt/homebrew/opt/openjdk/libexec/openjdk.jdk/Contents/Home"
+  ]
+    .filter(Boolean)
+    .map(resolvePath);
+  for (const candidate of candidates) {
+    if (fs.existsSync(path.join(candidate, "bin", "java")) && fs.existsSync(path.join(candidate, "bin", "jarsigner"))) {
+      return candidate;
+    }
+  }
+  const javaPath = which("java");
+  const jarsignerPath = which("jarsigner");
+  if (javaPath && jarsignerPath) {
+    return path.dirname(path.dirname(javaPath));
+  }
+  throw new BuildError(`could not find a JDK with java and jarsigner; searched ${candidates.join(", ")}`);
+}
+
+/**
+ * @param {string} command
+ * @returns {string}
+ */
+function which(command) {
+  const result = spawnSync("which", [command], { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] });
+  return result.status === 0 ? result.stdout.trim() : "";
+}
+
+/**
+ * @param {string} filePath
+ * @returns {Record<string, string>}
+ */
+function readProperties(filePath) {
+  /** @type {Record<string, string>} */
+  const properties = {};
+  for (const rawLine of fs.readFileSync(filePath, "utf8").split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#") || !line.includes("=")) {
+      continue;
+    }
+    const equalsIndex = line.indexOf("=");
+    properties[line.slice(0, equalsIndex).trim()] = line.slice(equalsIndex + 1).trim();
+  }
+  return properties;
+}
+
+/**
+ * @param {string} filePath
+ * @param {Record<string, string>} properties
+ */
+function writeProperties(filePath, properties) {
+  const lines = Object.entries(properties)
+    .sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey))
+    .map(([key, value]) => `${key}=${value}`);
+  fs.writeFileSync(filePath, `${lines.join("\n")}\n`, "utf8");
+}
+
+/**
+ * @param {Record<string, string>} properties
+ * @param {string} key
+ * @param {string} propertiesPath
+ * @returns {string}
+ */
+function requireProperty(properties, key, propertiesPath) {
+  const value = properties[key] || "";
+  if (!value) {
+    throw new BuildError(`missing signing property ${key} in ${propertiesPath}`);
+  }
+  return value;
+}
+
+/**
+ * @param {unknown} value
+ * @param {string} label
+ * @returns {string}
+ */
+function requireString(value, label) {
+  if (!value || typeof value !== "string") {
+    throw new BuildError(`missing ${label}`);
+  }
+  return value;
+}
+
+/**
+ * @param {unknown} value
+ * @param {string} label
+ * @returns {number}
+ */
+function requirePositiveInteger(value, label) {
+  const numberValue = Number(value);
+  if (!Number.isInteger(numberValue) || numberValue <= 0) {
+    throw new BuildError(`${label} must be a positive integer`);
+  }
+  return numberValue;
+}
+
+/**
+ * @param {string} filePath
+ * @param {string} label
+ */
+function requireFile(filePath, label) {
+  if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile()) {
+    throw new BuildError(`missing ${label}: ${filePath}`);
+  }
+  if (fs.statSync(filePath).size <= 0) {
+    throw new BuildError(`empty ${label}: ${filePath}`);
+  }
+}
+
+/**
+ * @param {string} directoryPath
+ * @param {string} label
+ */
+function requireDirectory(directoryPath, label) {
+  if (!fs.existsSync(directoryPath) || !fs.statSync(directoryPath).isDirectory()) {
+    throw new BuildError(`missing ${label}: ${directoryPath}`);
+  }
+}
+
+/**
+ * @param {string} executablePath
+ * @param {string} label
+ */
+function requireExecutable(executablePath, label) {
+  if (!executablePath || !fs.existsSync(executablePath)) {
+    throw new BuildError(`missing executable for ${label}: ${executablePath || label}`);
+  }
+}
+
+/**
+ * @param {string[]} command
+ * @param {{ cwd?: string; env?: NodeJS.ProcessEnv; quiet?: boolean }} options
+ */
+function run(command, options = {}) {
+  process.stdout.write(`+ ${command.join(" ")}${options.cwd ? ` in ${options.cwd}` : ""}\n`);
+  const result = spawnSync(command[0], command.slice(1), {
+    cwd: options.cwd,
+    env: options.env,
+    stdio: options.quiet ? ["ignore", "pipe", "pipe"] : "inherit",
+    encoding: "utf8"
+  });
+  if (result.error) {
+    throw new BuildError(`command failed: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    if (options.quiet) {
+      process.stderr.write(`${result.stdout || ""}${result.stderr || ""}`);
+    }
+    throw new BuildError(`command failed with exit ${result.status}: ${command.join(" ")}`);
+  }
+}
+
+/**
+ * @param {string[]} command
+ * @param {{ label: string }} options
+ * @returns {string}
+ */
+function runAndRead(command, options) {
+  const result = spawnSync(command[0], command.slice(1), { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+  if (result.error) {
+    throw new BuildError(`${options.label} failed: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    const detail = `${result.stdout || ""}${result.stderr || ""}`.trim();
+    throw new BuildError(`${options.label} failed with exit ${result.status}${detail ? `: ${detail}` : ""}`);
+  }
+  return result.stdout;
+}
+
+/**
+ * @param {string} output
+ * @returns {string}
+ */
+function ownerFromCertificateOutput(output) {
+  const ownerLine = output.split(/\r?\n/).find((line) => line.startsWith("Owner: "));
+  return ownerLine ? ownerLine.slice("Owner: ".length).trim() : "";
+}
+
+/**
+ * @param {string} output
+ * @param {string} label
+ * @returns {string}
+ */
+function certificateSha256FromOutput(output, label) {
+  const match = output.match(/SHA256:\s*([0-9A-Fa-f:]+)/);
+  if (!match) {
+    throw new BuildError(`could not read SHA-256 fingerprint from ${label}`);
+  }
+  return normalizeSha256Fingerprint(match[1]);
+}
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function normalizeSha256Fingerprint(value) {
+  const normalizedValue = value.trim().toUpperCase();
+  if (!normalizedValue) {
+    return "";
+  }
+  const compactValue = normalizedValue.replace(/:/g, "");
+  if (!/^[0-9A-F]{64}$/.test(compactValue)) {
+    throw new BuildError(`invalid SHA-256 fingerprint: ${value}`);
+  }
+  return compactValue.match(/.{2}/g)?.join(":") || "";
+}
+
+/**
+ * @param {string} outputPath
+ * @param {string} suffix
+ * @returns {string}
+ */
+function matchingOutputPath(outputPath, suffix) {
+  const parsed = path.parse(outputPath);
+  return path.join(parsed.dir, `${parsed.name}${suffix}`);
+}
+
+/**
+ * @param {string} mobileDir
+ * @param {string} version
+ * @returns {string}
+ */
+function defaultOutputPath(mobileDir, version) {
+  const safeVersion = version.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "release";
+  return path.join(mobileDir, "dist", `social-threader-${safeVersion}-android-release.aab`);
+}
+
+/**
+ * @param {string} filePath
+ * @returns {string}
+ */
+function sha256File(filePath) {
+  const hash = crypto.createHash("sha256");
+  hash.update(fs.readFileSync(filePath));
+  return hash.digest("hex");
+}

--- a/mobile/scripts/publish-android-play.mjs
+++ b/mobile/scripts/publish-android-play.mjs
@@ -1,0 +1,519 @@
+#!/usr/bin/env node
+// @ts-check
+/// <reference types="node" />
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(SCRIPT_DIR, "../..");
+const DEFAULT_MOBILE_DIR = path.join(REPO_ROOT, "mobile");
+const BUNDLE_SCHEMA = "social-threader.mobile-android-bundle.v1";
+const PUBLISH_SCHEMA = "social-threader.mobile-android-play-publish.v1";
+const ANDROID_PUBLISHER_API_BASE = "https://androidpublisher.googleapis.com/androidpublisher/v3/applications";
+const ANDROID_PUBLISHER_UPLOAD_BASE = "https://androidpublisher.googleapis.com/upload/androidpublisher/v3/applications";
+const ANDROID_PUBLISHER_SCOPE = "https://www.googleapis.com/auth/androidpublisher";
+const DEFAULT_TRACK = "internal";
+const DEFAULT_STATUS = "completed";
+
+class PublishError extends Error {
+  /**
+   * @param {string} message
+   */
+  constructor(message) {
+    super(message);
+    this.name = "PublishError";
+  }
+}
+
+try {
+  const args = parseArgs(process.argv.slice(2));
+  const result = await publishAndroidBundle(args);
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+} catch (error) {
+  if (error instanceof PublishError) {
+    process.stderr.write(`mobile android play publish failed: ${error.message}\n`);
+    process.exit(2);
+  }
+  throw error;
+}
+
+/**
+ * @typedef {{
+ *   mobileDir: string;
+ *   aab: string;
+ *   mapping: string;
+ *   buildManifest: string;
+ *   packageName: string;
+ *   quotaProject: string;
+ *   track: string;
+ *   status: string;
+ *   releaseName: string;
+ *   dryRun: boolean;
+ * }} PublishArgs
+ */
+
+/**
+ * @param {string[]} argv
+ * @returns {PublishArgs}
+ */
+function parseArgs(argv) {
+  const options = new Map();
+  const flags = new Set();
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--dry-run") {
+      flags.add("dry-run");
+      continue;
+    }
+    if (!token.startsWith("--")) {
+      throw new PublishError(`unexpected positional argument: ${token}`);
+    }
+    const equalsIndex = token.indexOf("=");
+    if (equalsIndex > 0) {
+      options.set(token.slice(2, equalsIndex), token.slice(equalsIndex + 1));
+      continue;
+    }
+    const optionName = token.slice(2);
+    const optionValue = argv[index + 1];
+    if (!optionValue || optionValue.startsWith("--")) {
+      throw new PublishError(`missing value for --${optionName}`);
+    }
+    options.set(optionName, optionValue);
+    index += 1;
+  }
+
+  const mobileDir = resolvePath(String(options.get("mobile-dir") || DEFAULT_MOBILE_DIR));
+  const appConfig = readAndroidAppConfig(mobileDir);
+  const releaseIdentity = readAndroidReleaseIdentity(mobileDir);
+  const packageName = String(options.get("package-name") || releaseIdentity.packageName || appConfig.packageName);
+  if (packageName !== appConfig.packageName) {
+    throw new PublishError(`package name mismatch: app.json has ${appConfig.packageName}, publish target is ${packageName}`);
+  }
+  if (releaseIdentity.packageName && packageName !== releaseIdentity.packageName) {
+    throw new PublishError(`package name mismatch: release identity has ${releaseIdentity.packageName}, publish target is ${packageName}`);
+  }
+
+  const aab = resolvePath(String(options.get("aab") || defaultAabPath(mobileDir, appConfig.version)));
+  const mapping = resolvePath(String(options.get("mapping") || matchingOutputPath(aab, "-mapping.txt")));
+  const buildManifest = resolvePath(String(options.get("build-manifest") || matchingBuildManifestPath(aab)));
+  const quotaProject = String(
+    options.get("quota-project") ||
+      process.env.GOOGLE_CLOUD_QUOTA_PROJECT ||
+      process.env.GCLOUD_QUOTA_PROJECT ||
+      releaseIdentity.googleCloudProjectId ||
+      ""
+  );
+  const track = String(options.get("track") || process.env.SOCIAL_THREADER_ANDROID_PLAY_TRACK || DEFAULT_TRACK);
+  const status = String(options.get("status") || process.env.SOCIAL_THREADER_ANDROID_PLAY_STATUS || DEFAULT_STATUS);
+  const releaseName = String(options.get("release-name") || appConfig.version);
+  requireTrack(track);
+  requireReleaseStatus(status);
+
+  return {
+    mobileDir,
+    aab,
+    mapping,
+    buildManifest,
+    packageName,
+    quotaProject,
+    track,
+    status,
+    releaseName,
+    dryRun: flags.has("dry-run")
+  };
+}
+
+/**
+ * @param {PublishArgs} args
+ * @returns {Promise<Record<string, unknown>>}
+ */
+async function publishAndroidBundle(args) {
+  const appConfig = readAndroidAppConfig(args.mobileDir);
+  requireFile(args.aab, "Android App Bundle");
+  requireFile(args.mapping, "R8 deobfuscation mapping file");
+  const buildArtifact = readAndroidBuildManifest(args.buildManifest, args.aab, args.mapping, appConfig);
+  if (buildArtifact.androidPackage !== args.packageName) {
+    throw new PublishError(`build manifest package mismatch: manifest has ${buildArtifact.androidPackage}, publish target is ${args.packageName}`);
+  }
+  if (!args.quotaProject && !args.dryRun) {
+    throw new PublishError("missing Google Cloud quota project; pass --quota-project or set GOOGLE_CLOUD_QUOTA_PROJECT");
+  }
+
+  const plan = {
+    schema: PUBLISH_SCHEMA,
+    status: args.dryRun ? "planned" : "submitted",
+    androidPackage: args.packageName,
+    versionName: buildArtifact.versionName,
+    versionCode: buildArtifact.versionCode,
+    sourceVersionCode: buildArtifact.sourceVersionCode,
+    versionCodeSource: buildArtifact.versionCodeSource,
+    versionCodePolicy: buildArtifact.versionCodePolicy,
+    googlePlayMaxVersionCode: buildArtifact.googlePlayMaxVersionCode,
+    buildManifest: args.buildManifest,
+    track: args.track,
+    releaseName: args.releaseName,
+    releaseStatus: args.status,
+    aab: args.aab,
+    aabSha256: sha256File(args.aab),
+    deobfuscationFile: args.mapping,
+    deobfuscationSha256: sha256File(args.mapping),
+    quotaProject: args.quotaProject
+  };
+  if (args.dryRun) {
+    return plan;
+  }
+
+  const token = accessTokenFromApplicationDefaultCredentials();
+  const authHeaders = googleAuthHeaders(token, args.quotaProject);
+  const edit = await requestJson({
+    method: "POST",
+    url: publisherUrl(args.packageName, "edits"),
+    headers: authHeaders,
+    label: "create Android Publisher edit"
+  });
+  const editId = requireString(edit.id, "edit id");
+
+  const bundle = await requestJson({
+    method: "POST",
+    url: publisherUploadUrl(args.packageName, `edits/${encodeURIComponent(editId)}/bundles`, { uploadType: "media" }),
+    headers: { ...authHeaders, "Content-Type": "application/octet-stream" },
+    body: fs.readFileSync(args.aab),
+    label: "upload Android App Bundle"
+  });
+  const uploadedVersionCode = requirePositiveInteger(bundle.versionCode, "uploaded bundle versionCode");
+  if (uploadedVersionCode !== buildArtifact.versionCode) {
+    throw new PublishError(`uploaded bundle versionCode ${uploadedVersionCode} does not match build manifest ${buildArtifact.versionCode}`);
+  }
+
+  await requestJson({
+    method: "POST",
+    url: publisherUploadUrl(
+      args.packageName,
+      `edits/${encodeURIComponent(editId)}/apks/${uploadedVersionCode}/deobfuscationFiles/proguard`,
+      { uploadType: "media" }
+    ),
+    headers: { ...authHeaders, "Content-Type": "application/octet-stream" },
+    body: fs.readFileSync(args.mapping),
+    label: "upload Android deobfuscation mapping"
+  });
+
+  await requestJson({
+    method: "PUT",
+    url: publisherUrl(args.packageName, `edits/${encodeURIComponent(editId)}/tracks/${encodeURIComponent(args.track)}`),
+    headers: { ...authHeaders, "Content-Type": "application/json" },
+    body: Buffer.from(
+      JSON.stringify({
+        releases: [
+          {
+            name: args.releaseName,
+            versionCodes: [String(uploadedVersionCode)],
+            status: args.status
+          }
+        ]
+      })
+    ),
+    label: `update ${args.track} track`
+  });
+
+  const commit = await requestJson({
+    method: "POST",
+    url: publisherUrl(args.packageName, `edits/${encodeURIComponent(editId)}:commit`),
+    headers: authHeaders,
+    label: "commit Android Publisher edit"
+  });
+
+  return {
+    ...plan,
+    editId,
+    committedEditId: commit.id || editId,
+    uploadedVersionCode
+  };
+}
+
+/**
+ * @param {string} mobileDir
+ * @returns {{ version: string; versionCode: number; packageName: string }}
+ */
+function readAndroidAppConfig(mobileDir) {
+  const appJsonPath = path.join(mobileDir, "app.json");
+  requireFile(appJsonPath, "mobile app.json");
+  const appConfig = JSON.parse(fs.readFileSync(appJsonPath, "utf8"));
+  const expoConfig = appConfig.expo || {};
+  const androidConfig = expoConfig.android || {};
+  return {
+    version: requireString(expoConfig.version, `expo.version in ${appJsonPath}`),
+    versionCode: requirePositiveInteger(androidConfig.versionCode, `expo.android.versionCode in ${appJsonPath}`),
+    packageName: requireString(androidConfig.package, `expo.android.package in ${appJsonPath}`)
+  };
+}
+
+/**
+ * @param {string} mobileDir
+ * @returns {{ packageName: string; googleCloudProjectId: string }}
+ */
+function readAndroidReleaseIdentity(mobileDir) {
+  const identityPath = path.join(mobileDir, "android-release-identity.json");
+  if (!fs.existsSync(identityPath)) {
+    return { packageName: "", googleCloudProjectId: "" };
+  }
+  const identity = JSON.parse(fs.readFileSync(identityPath, "utf8"));
+  return {
+    packageName: typeof identity.packageName === "string" ? identity.packageName : "",
+    googleCloudProjectId: typeof identity.googleCloudProjectId === "string" ? identity.googleCloudProjectId : ""
+  };
+}
+
+/**
+ * @param {string} manifestPath
+ * @param {string} aabPath
+ * @param {string} mappingPath
+ * @param {{ version: string; packageName: string }} appConfig
+ * @returns {{ androidPackage: string; versionName: string; versionCode: number; sourceVersionCode: number; versionCodeSource: string; versionCodePolicy: string; googlePlayMaxVersionCode: number | null }}
+ */
+function readAndroidBuildManifest(manifestPath, aabPath, mappingPath, appConfig) {
+  requireFile(manifestPath, "Android bundle build manifest");
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  if (manifest.schema !== BUNDLE_SCHEMA) {
+    throw new PublishError(`invalid Android bundle build manifest schema in ${manifestPath}`);
+  }
+  if (manifest.status !== "passed") {
+    throw new PublishError(`Android bundle build manifest is not passed: ${manifestPath}`);
+  }
+  const manifestAab = resolvePath(requireString(manifest.output, `output in ${manifestPath}`));
+  const manifestMapping = resolvePath(requireString(manifest.deobfuscationFile, `deobfuscationFile in ${manifestPath}`));
+  if (manifestAab !== aabPath) {
+    throw new PublishError(`Android bundle build manifest output mismatch: ${manifestAab} != ${aabPath}`);
+  }
+  if (manifestMapping !== mappingPath) {
+    throw new PublishError(`Android bundle build manifest mapping mismatch: ${manifestMapping} != ${mappingPath}`);
+  }
+  if (manifest.sha256 !== sha256File(aabPath)) {
+    throw new PublishError(`Android App Bundle hash changed since build manifest: ${aabPath}`);
+  }
+  if (manifest.deobfuscationSha256 !== sha256File(mappingPath)) {
+    throw new PublishError(`R8 deobfuscation mapping hash changed since build manifest: ${mappingPath}`);
+  }
+  const versionName = requireString(manifest.versionName, `versionName in ${manifestPath}`);
+  if (versionName !== appConfig.version) {
+    throw new PublishError(`build manifest versionName ${versionName} does not match app.json ${appConfig.version}`);
+  }
+  return {
+    androidPackage: requireString(manifest.androidPackage, `androidPackage in ${manifestPath}`),
+    versionName,
+    versionCode: requirePositiveInteger(manifest.versionCode, `versionCode in ${manifestPath}`),
+    sourceVersionCode: requirePositiveInteger(manifest.sourceVersionCode, `sourceVersionCode in ${manifestPath}`),
+    versionCodeSource: requireString(manifest.versionCodeSource, `versionCodeSource in ${manifestPath}`),
+    versionCodePolicy: requireString(manifest.versionCodePolicy, `versionCodePolicy in ${manifestPath}`),
+    googlePlayMaxVersionCode:
+      manifest.googlePlayMaxVersionCode === null || manifest.googlePlayMaxVersionCode === undefined
+        ? null
+        : requireNonNegativeInteger(manifest.googlePlayMaxVersionCode, `googlePlayMaxVersionCode in ${manifestPath}`)
+  };
+}
+
+/**
+ * @returns {string}
+ */
+function accessTokenFromApplicationDefaultCredentials() {
+  const result = spawnSync("gcloud", ["auth", "application-default", "print-access-token"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+  if (result.error) {
+    throw new PublishError(`could not run gcloud for ADC token: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    const detail = `${result.stdout || ""}${result.stderr || ""}`.trim();
+    throw new PublishError(
+      `could not read Google Application Default Credentials token with ${ANDROID_PUBLISHER_SCOPE}; ` +
+        `run gcloud auth application-default login --scopes=${ANDROID_PUBLISHER_SCOPE},https://www.googleapis.com/auth/cloud-platform` +
+        (detail ? `: ${detail}` : "")
+    );
+  }
+  return result.stdout.trim();
+}
+
+/**
+ * @param {string} token
+ * @param {string} quotaProject
+ * @returns {Record<string, string>}
+ */
+function googleAuthHeaders(token, quotaProject) {
+  const headers = { Authorization: `Bearer ${token}` };
+  if (quotaProject) {
+    headers["X-Goog-User-Project"] = quotaProject;
+  }
+  return headers;
+}
+
+/**
+ * @param {{ method: string; url: string; headers: Record<string, string>; body?: Buffer; label: string }} request
+ * @returns {Promise<Record<string, unknown>>}
+ */
+async function requestJson(request) {
+  const response = await fetch(request.url, {
+    method: request.method,
+    headers: request.headers,
+    body: request.body ? new Uint8Array(request.body) : undefined
+  });
+  const body = await response.text();
+  if (!response.ok) {
+    throw new PublishError(`${request.label} failed with HTTP ${response.status}: ${body.slice(0, 4096)}`);
+  }
+  if (!body.trim()) {
+    return {};
+  }
+  const payload = JSON.parse(body);
+  if (!payload || typeof payload !== "object") {
+    throw new PublishError(`${request.label} returned a non-object JSON response`);
+  }
+  return payload;
+}
+
+/**
+ * @param {string} packageName
+ * @param {string} pathSuffix
+ * @returns {string}
+ */
+function publisherUrl(packageName, pathSuffix) {
+  return `${ANDROID_PUBLISHER_API_BASE}/${encodeURIComponent(packageName)}/${pathSuffix}`;
+}
+
+/**
+ * @param {string} packageName
+ * @param {string} pathSuffix
+ * @param {Record<string, string>} query
+ * @returns {string}
+ */
+function publisherUploadUrl(packageName, pathSuffix, query) {
+  return `${ANDROID_PUBLISHER_UPLOAD_BASE}/${encodeURIComponent(packageName)}/${pathSuffix}?${new URLSearchParams(query).toString()}`;
+}
+
+/**
+ * @param {string} mobileDir
+ * @param {string} version
+ * @returns {string}
+ */
+function defaultAabPath(mobileDir, version) {
+  const safeVersion = version.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "release";
+  return path.join(mobileDir, "dist", `social-threader-${safeVersion}-android-release.aab`);
+}
+
+/**
+ * @param {string} outputPath
+ * @param {string} suffix
+ * @returns {string}
+ */
+function matchingOutputPath(outputPath, suffix) {
+  const parsed = path.parse(outputPath);
+  return path.join(parsed.dir, `${parsed.name}${suffix}`);
+}
+
+/**
+ * @param {string} outputPath
+ * @returns {string}
+ */
+function matchingBuildManifestPath(outputPath) {
+  const parsed = path.parse(outputPath);
+  return path.join(parsed.dir, `${parsed.name}.json`);
+}
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function resolvePath(value) {
+  if (!value) {
+    return "";
+  }
+  if (value === "~") {
+    return process.env.HOME || "";
+  }
+  if (value.startsWith("~/")) {
+    return path.join(process.env.HOME || "", value.slice(2));
+  }
+  return path.resolve(value);
+}
+
+/**
+ * @param {unknown} value
+ * @param {string} label
+ * @returns {string}
+ */
+function requireString(value, label) {
+  if (!value || typeof value !== "string") {
+    throw new PublishError(`missing ${label}`);
+  }
+  return value;
+}
+
+/**
+ * @param {unknown} value
+ * @param {string} label
+ * @returns {number}
+ */
+function requirePositiveInteger(value, label) {
+  const numberValue = Number(value);
+  if (!Number.isInteger(numberValue) || numberValue <= 0) {
+    throw new PublishError(`${label} must be a positive integer`);
+  }
+  return numberValue;
+}
+
+/**
+ * @param {unknown} value
+ * @param {string} label
+ * @returns {number}
+ */
+function requireNonNegativeInteger(value, label) {
+  const numberValue = Number(value);
+  if (!Number.isInteger(numberValue) || numberValue < 0) {
+    throw new PublishError(`${label} must be a non-negative integer`);
+  }
+  return numberValue;
+}
+
+/**
+ * @param {string} filePath
+ * @param {string} label
+ */
+function requireFile(filePath, label) {
+  if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile()) {
+    throw new PublishError(`missing ${label}: ${filePath}`);
+  }
+  if (fs.statSync(filePath).size <= 0) {
+    throw new PublishError(`empty ${label}: ${filePath}`);
+  }
+}
+
+/**
+ * @param {string} track
+ */
+function requireTrack(track) {
+  if (!/^[A-Za-z0-9._-]+$/.test(track)) {
+    throw new PublishError(`invalid Play track: ${track}`);
+  }
+}
+
+/**
+ * @param {string} status
+ */
+function requireReleaseStatus(status) {
+  if (!new Set(["completed", "draft", "inProgress", "halted"]).has(status)) {
+    throw new PublishError(`invalid Play release status: ${status}`);
+  }
+}
+
+/**
+ * @param {string} filePath
+ * @returns {string}
+ */
+function sha256File(filePath) {
+  const hash = crypto.createHash("sha256");
+  hash.update(fs.readFileSync(filePath));
+  return hash.digest("hex");
+}

--- a/mobile/scripts/validate-config.mjs
+++ b/mobile/scripts/validate-config.mjs
@@ -34,6 +34,8 @@ assertEqual(packageJson.devDependencies?.playwright, undefined, "mobile dev pack
 assertExecutable("scripts/ios-run.mjs", "iOS local-run launcher must be executable");
 assertExecutable("scripts/expo-run.expect", "Expo local-run prompt wrapper must be executable");
 assertExecutable("scripts/android-run.mjs", "Android local-run launcher must be executable");
+assertExecutable("scripts/build-android-bundle.mjs", "Android release bundle builder must be executable");
+assertExecutable("scripts/publish-android-play.mjs", "Android Play publisher must be executable");
 assertSharedWebCopies();
 assertEqual(appJson.expo?.name, "Social Threader", "native app name must be stable");
 assertEqual(appJson.expo?.scheme, "socialthreader", "native URL scheme must be stable");
@@ -55,7 +57,7 @@ assertNumber(appJson.expo?.android?.versionCode, "Android versionCode must be nu
 assertProjectFile(appJson.expo?.android?.adaptiveIcon?.foregroundImage, "Android adaptive icon must be stored inside mobile/");
 assertProjectFile(appJson.expo?.web?.favicon, "Web favicon must be stored inside mobile/");
 assertEqual(easJson.build?.production?.distribution, "store", "EAS production profile must target stores");
-assertEqual(easJson.build?.production?.android?.buildType, "app-bundle", "EAS Android production profile must emit AAB");
+assertEqual(easJson.build?.production?.android, undefined, "Android store publishing must not use EAS");
 
 console.log("Social Threader mobile config validation passed.");
 


### PR DESCRIPTION
### Add Local Android App Bundle Build and Play Store Automation

This update introduces a custom workflow for building and publishing the Android App Bundle (AAB) for the mobile project using local tooling, replacing the previous EAS build path. The main changes include:

- Adds scripts to locally prebuild, sign, and bundle the Android app using Gradle, drawing credentials from local, git-ignored files.  
- Provides Play Store publish automation via a Node.js script integrating with the Google Play Android Publisher API, using Application Default Credentials for secure upload.
- Updates the Makefile to replace EAS-based Android build and submit steps with these local scripts and custom variables for keys, paths, and versions.
- Updates `.gitignore` to ensure upload keystore, signing properties, and bundle output files are excluded from source control.
- Adds and documents an example Android release identity JSON, and enhances documentation with instructions for managing Play Store credentials and build artifacts in a secure, reproducible manner.

These improvements ensure fully local, replicable Android release builds, better credential hygiene, and more straightforward Play Store deployments within the developer workflow.