### PR TITLE
gix/install-dev-dependencies-in-android-release-builds

### DIFF
--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -8,6 +8,35 @@ Format: `- [ ] [B042] (P1) {I007} Title`
 
 ## BugFixes
 
+- [ ] [B001] (P1) Remove NODE_ENV from the `npm ci` step of the mobile client build
+  Goal:
+  The Android release build fails in Metro. Metro cannot find `babel-preset-expo`. The Ansible task `build-selected-release-mobile-platform.yml` sets `NODE_ENV: production` for the build. The build tool `mobile/scripts/build-android-bundle.mjs` uses that value in its `npm ci` step. npm does not install `devDependencies` when `NODE_ENV` has the value `production`. The `mobile/package.json` has `babel-preset-expo` in its `devDependencies`.
+  The release process fails with the value 2. The build records no release receipt. The end user can operate `make release` again. The build tool already sets `NODE_ENV=production` for the Gradle step. The `mprlab-gateway` value is not necessary for that step. The release builds this repository at `64c1fc0` and `mprlab-gateway` at `7d7603e`.
+
+  Requirements:
+  - Remove `NODE_ENV` from the environment in `buildEnvironment` in `mobile/scripts/build-android-bundle.mjs`.
+  - Keep the `NODE_ENV=production` value for the Gradle step.
+  - Keep `babel-preset-expo` in the `devDependencies` of `mobile/package.json`.
+  - Keep the change in this repository.
+  - Make the build tool operate under any environment.
+  - Add a regression test for the `npm ci` step under `NODE_ENV=production`.
+  - Verify that `babel-preset-expo` is in `node_modules` after the step.
+
+  Deliverables:
+  - A change to `buildEnvironment` in `mobile/scripts/build-android-bundle.mjs` that removes `NODE_ENV` from the environment.
+  - A regression test that verifies the `npm ci` step installs `devDependencies` under `NODE_ENV=production`.
+  - Documentation in `mobile/README.md` that records the build environment contract.
+
+  Verification:
+  - Operate the regression test before the change.
+  - Make sure that the test fails before the change and shows the correct result after the change.
+  - Operate `make mobile-check`.
+  - Operate `make ci` one time after the last change.
+  - Operate `git diff --check`.
+  - The end user operates `make release`.
+  - Make sure that the release records the Android AAB.
+  - Make sure that Metro shows no error.
+
 ## Improvements
 
 ## Maintenance

--- a/.mprlab/POLICY.md
+++ b/.mprlab/POLICY.md
@@ -27,6 +27,22 @@ This policy controls all agent work in this repository.
 - Hardcoded workflow, path, event, or message literals when a canonical constant or backend payload exists.
 - Unit tests as a substitute for public contract coverage.
 
+## Credential Discovery
+
+- Identify each required environment variable from the active command and repository contract.
+- Inspect the process environment before you request a login.
+- Inspect repository private environment files before you report a credential blocker.
+- Include ignored `.env`, `.env.*`, and `*.env` files in the authorized repository roots.
+- Treat tracked example and sample environment files as documentation only.
+- Search only for exact variable names. Do not print, copy, or record secret values.
+- When a command declares one repository environment file as its input, clear
+  its owned process variables and source only that file.
+- Use the command's standard environment lookup. Do not add a credential parser
+  or another input channel.
+- When available, use a non-mutating authentication command to verify the discovered value.
+- Request new credentials only after each authorized existing input fails verification.
+- Report a credential blocker only after you complete this gate.
+
 ## Validation
 
 - Use repository-native `make` targets when available.

--- a/.mprlab/TERMINOLOGY.md
+++ b/.mprlab/TERMINOLOGY.md
@@ -72,12 +72,16 @@ Give each term one meaning. Use the same term for the same concept in all docume
 Add repository-specific technical nouns below this line.
 
 - `application profile`: A config record that defines one browser, API, TAuth, cookie, CORS, DNS, and runtime topology.
+- `environment`: The values that one process gives to another process.
 - `fake LLM Proxy`: A local service that implements the necessary LLM Proxy HTTP boundary without a provider call.
 - `idempotency record`: A short-lived memory record that connects one authenticated subject and request ID to one result.
 - `LLM Proxy`: The MPR Lab service that owns model-provider routing and provider credentials.
 - `local stack`: The app-owned Docker Compose topology for local development and black-box validation.
 - `mpr-ui`: The shared browser component library that owns the TAuth browser lifecycle.
 - `prompt catalog`: The server-owned set of versioned thread transformation instructions.
+- `regression test`: A test that checks one defect after a change to the source code.
+- `release`: One sealed build of the repository.
+- `release receipt`: The record that shows that one release completed its build steps.
 - `TAuth`: The shared authentication service that issues and validates profile-specific sessions.
 - `thread transformation`: One server-owned text edit that uses a closed product operation.
 - `transformation coordinator`: The browser module that owns transformation UI state and request cancellation.

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -43,7 +43,7 @@ make submit-android
 
 `make build-ios` uses the `production` EAS profile. `make build-android` is a lower-level development helper. Expo prebuilds Android in a temporary directory. Gradle creates a signed App Bundle. The script writes a checked build manifest beside the `.aab`.
 
-The Android build tool removes `NODE_ENV` from the environment of the `npm ci` step. This makes `npm ci` install all devDependencies. The Gradle step sets `NODE_ENV` to `production`.
+The Android build tool removes `NODE_ENV` and operates `npm ci --include=dev`. This command installs all devDependencies in every environment. The Gradle step sets `NODE_ENV` to `production`.
 
 `make run-ios` starts Metro through `scripts/ios-run.mjs`. It selects an available Expo port before startup. Then, `scripts/expo-run.expect` accepts known Expo Go upgrades and rejects unexpected port changes.
 

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -43,6 +43,8 @@ make submit-android
 
 `make build-ios` uses the `production` EAS profile. `make build-android` is a lower-level development helper. Expo prebuilds Android in a temporary directory. Gradle creates a signed App Bundle. The script writes a checked build manifest beside the `.aab`.
 
+The Android build tool removes `NODE_ENV` from the environment of the `npm ci` step. This makes `npm ci` install all devDependencies. The Gradle step sets `NODE_ENV` to `production`.
+
 `make run-ios` starts Metro through `scripts/ios-run.mjs`. It selects an available Expo port before startup. Then, `scripts/expo-run.expect` accepts known Expo Go upgrades and rejects unexpected port changes.
 
 `make run-android` starts Metro through `scripts/android-run.mjs`. It starts an Android AVD when necessary and installs a compatible Expo Go build. Then, it configures `adb reverse`, opens the local Expo address, and verifies the Social Threader UI. Override the Metro port with `MOBILE_PORT=8082 make run-ios` or `MOBILE_PORT=8082 make run-android`.

--- a/mobile/__tests__/buildEnvironment.test.js
+++ b/mobile/__tests__/buildEnvironment.test.js
@@ -3,26 +3,35 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { buildEnvironment } from "../scripts/lib/build-environment.mjs";
+import { buildEnvironment, NPM_CI_ARGUMENTS } from "../scripts/lib/build-environment.mjs";
 
 const MOBILE_DIR = path.resolve(__dirname, "..");
 const NPM_CI_STEP_TIMEOUT_MS = 300000;
+const CALLER_PRODUCTION_ENVIRONMENT = Object.freeze({
+  NODE_ENV: "production",
+  NPM_CONFIG_PRODUCTION: "true",
+  NPM_CONFIG_OMIT: "dev"
+});
 
 describe("android bundle build environment", () => {
-  let savedNodeEnv;
+  let savedCallerEnvironment;
   let workDir;
 
   beforeAll(() => {
-    savedNodeEnv = process.env.NODE_ENV;
-    process.env.NODE_ENV = "production";
+    savedCallerEnvironment = Object.fromEntries(
+      Object.keys(CALLER_PRODUCTION_ENVIRONMENT).map((variableName) => [variableName, process.env[variableName]])
+    );
+    Object.assign(process.env, CALLER_PRODUCTION_ENVIRONMENT);
     workDir = fs.mkdtempSync(path.join(os.tmpdir(), "social-threader-mobile-build-env-"));
   });
 
   afterAll(() => {
-    if (savedNodeEnv === undefined) {
-      delete process.env.NODE_ENV;
-    } else {
-      process.env.NODE_ENV = savedNodeEnv;
+    for (const [variableName, variableValue] of Object.entries(savedCallerEnvironment)) {
+      if (variableValue === undefined) {
+        delete process.env[variableName];
+      } else {
+        process.env[variableName] = variableValue;
+      }
     }
     fs.rmSync(workDir, { recursive: true, force: true });
   });
@@ -33,12 +42,14 @@ describe("android bundle build environment", () => {
     const environment = buildEnvironment(javaHome, androidSdkRoot);
 
     expect(environment.NODE_ENV).toBeUndefined();
+    expect(environment.NPM_CONFIG_PRODUCTION).toBe("true");
+    expect(environment.NPM_CONFIG_OMIT).toBe("dev");
     expect(environment.JAVA_HOME).toBe(javaHome);
     expect(environment.ANDROID_SDK_ROOT).toBe(androidSdkRoot);
     expect(environment.PATH.startsWith(`${path.join(javaHome, "bin")}${path.delimiter}`)).toBe(true);
   });
 
-  it("installs devDependencies through the npm ci step under NODE_ENV=production", () => {
+  it("installs devDependencies through npm ci under inherited production settings", () => {
     const javaHome = path.join(workDir, "java");
     const androidSdkRoot = path.join(workDir, "android-sdk");
     const environment = buildEnvironment(javaHome, androidSdkRoot);
@@ -48,7 +59,7 @@ describe("android bundle build environment", () => {
     fs.copyFileSync(path.join(MOBILE_DIR, "package.json"), path.join(installDir, "package.json"));
     fs.copyFileSync(path.join(MOBILE_DIR, "package-lock.json"), path.join(installDir, "package-lock.json"));
 
-    const result = spawnSync("npm", ["ci"], {
+    const result = spawnSync("npm", NPM_CI_ARGUMENTS, {
       cwd: installDir,
       env: environment,
       stdio: ["ignore", "pipe", "pipe"],

--- a/mobile/__tests__/buildEnvironment.test.js
+++ b/mobile/__tests__/buildEnvironment.test.js
@@ -1,0 +1,63 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { buildEnvironment } from "../scripts/lib/build-environment.mjs";
+
+const MOBILE_DIR = path.resolve(__dirname, "..");
+const NPM_CI_STEP_TIMEOUT_MS = 300000;
+
+describe("android bundle build environment", () => {
+  let savedNodeEnv;
+  let workDir;
+
+  beforeAll(() => {
+    savedNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), "social-threader-mobile-build-env-"));
+  });
+
+  afterAll(() => {
+    if (savedNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = savedNodeEnv;
+    }
+    fs.rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it("builds an environment without the caller NODE_ENV", () => {
+    const javaHome = path.join(workDir, "java");
+    const androidSdkRoot = path.join(workDir, "android-sdk");
+    const environment = buildEnvironment(javaHome, androidSdkRoot);
+
+    expect(environment.NODE_ENV).toBeUndefined();
+    expect(environment.JAVA_HOME).toBe(javaHome);
+    expect(environment.ANDROID_SDK_ROOT).toBe(androidSdkRoot);
+    expect(environment.PATH.startsWith(`${path.join(javaHome, "bin")}${path.delimiter}`)).toBe(true);
+  });
+
+  it("installs devDependencies through the npm ci step under NODE_ENV=production", () => {
+    const javaHome = path.join(workDir, "java");
+    const androidSdkRoot = path.join(workDir, "android-sdk");
+    const environment = buildEnvironment(javaHome, androidSdkRoot);
+
+    const installDir = path.join(workDir, "install");
+    fs.mkdirSync(installDir, { recursive: true });
+    fs.copyFileSync(path.join(MOBILE_DIR, "package.json"), path.join(installDir, "package.json"));
+    fs.copyFileSync(path.join(MOBILE_DIR, "package-lock.json"), path.join(installDir, "package-lock.json"));
+
+    const result = spawnSync("npm", ["ci"], {
+      cwd: installDir,
+      env: environment,
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf8"
+    });
+    if (result.status !== 0) {
+      throw new Error(`npm ci failed with exit ${result.status}: ${result.stdout || ""}${result.stderr || ""}`);
+    }
+
+    expect(fs.existsSync(path.join(installDir, "node_modules", "babel-preset-expo", "package.json"))).toBe(true);
+  }, NPM_CI_STEP_TIMEOUT_MS);
+});

--- a/mobile/scripts/build-android-bundle.mjs
+++ b/mobile/scripts/build-android-bundle.mjs
@@ -9,6 +9,8 @@ import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
+import { buildEnvironment } from "./lib/build-environment.mjs";
+
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(SCRIPT_DIR, "../..");
 const DEFAULT_MOBILE_DIR = path.join(REPO_ROOT, "mobile");
@@ -748,33 +750,6 @@ function patchAndroidVersionCodeInAppJson(mobileDir, versionCode) {
   payload.expo.android = payload.expo.android || {};
   payload.expo.android.versionCode = versionCode;
   fs.writeFileSync(appJsonPath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
-}
-
-/**
- * @param {string} javaHome
- * @param {string} androidSdkRoot
- * @returns {NodeJS.ProcessEnv}
- */
-function buildEnvironment(javaHome, androidSdkRoot) {
-  const environment = {
-    ...process.env,
-    CI: "1",
-    EXPO_NO_TELEMETRY: "1",
-    JAVA_HOME: javaHome,
-    ANDROID_HOME: androidSdkRoot,
-    ANDROID_SDK_ROOT: androidSdkRoot,
-    PATH: [
-      path.join(javaHome, "bin"),
-      path.join(androidSdkRoot, "platform-tools"),
-      path.join(androidSdkRoot, "cmdline-tools", "latest", "bin"),
-      process.env.PATH || ""
-    ]
-      .filter(Boolean)
-      .join(path.delimiter)
-  };
-  delete environment.FORCE_COLOR;
-  delete environment.NO_COLOR;
-  return environment;
 }
 
 /**

--- a/mobile/scripts/build-android-bundle.mjs
+++ b/mobile/scripts/build-android-bundle.mjs
@@ -9,7 +9,7 @@ import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
-import { buildEnvironment } from "./lib/build-environment.mjs";
+import { buildEnvironment, NPM_CI_ARGUMENTS } from "./lib/build-environment.mjs";
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(SCRIPT_DIR, "../..");
@@ -176,7 +176,7 @@ function buildAndroidBundle(args) {
   patchAndroidVersionCodeInAppJson(buildMobileDir, versionCodeResolution.versionCode);
 
   const env = buildEnvironment(args.javaHome, args.androidSdkRoot);
-  run(["npm", "ci"], { cwd: buildMobileDir, env });
+  run(["npm", ...NPM_CI_ARGUMENTS], { cwd: buildMobileDir, env });
   patchGeneratedAndroidDependencySources(buildMobileDir);
   run(["npx", "--no-install", "expo", "prebuild", "--platform", "android", "--no-install"], { cwd: buildMobileDir, env });
   writeLocalProperties(path.join(buildMobileDir, "android", "local.properties"), args.androidSdkRoot);

--- a/mobile/scripts/lib/build-environment.mjs
+++ b/mobile/scripts/lib/build-environment.mjs
@@ -1,0 +1,35 @@
+// @ts-check
+import path from "node:path";
+
+/**
+ * Build the environment for the Android bundle build steps.
+ *
+ * NODE_ENV is removed so the `npm ci` step always installs devDependencies.
+ * The Gradle step sets NODE_ENV to production on its own.
+ *
+ * @param {string} javaHome
+ * @param {string} androidSdkRoot
+ * @returns {NodeJS.ProcessEnv}
+ */
+export function buildEnvironment(javaHome, androidSdkRoot) {
+  const environment = {
+    ...process.env,
+    CI: "1",
+    EXPO_NO_TELEMETRY: "1",
+    JAVA_HOME: javaHome,
+    ANDROID_HOME: androidSdkRoot,
+    ANDROID_SDK_ROOT: androidSdkRoot,
+    PATH: [
+      path.join(javaHome, "bin"),
+      path.join(androidSdkRoot, "platform-tools"),
+      path.join(androidSdkRoot, "cmdline-tools", "latest", "bin"),
+      process.env.PATH || ""
+    ]
+      .filter(Boolean)
+      .join(path.delimiter)
+  };
+  delete environment.FORCE_COLOR;
+  delete environment.NO_COLOR;
+  delete environment.NODE_ENV;
+  return environment;
+}

--- a/mobile/scripts/lib/build-environment.mjs
+++ b/mobile/scripts/lib/build-environment.mjs
@@ -1,6 +1,9 @@
 // @ts-check
 import path from "node:path";
 
+/** @type {readonly string[]} */
+export const NPM_CI_ARGUMENTS = Object.freeze(["ci", "--include=dev"]);
+
 /**
  * Build the environment for the Android bundle build steps.
  *

--- a/mobile/scripts/validate-config.mjs
+++ b/mobile/scripts/validate-config.mjs
@@ -162,8 +162,10 @@ assertIncludes(androidBuildSource, "ModuleRegistryAdapter.java", "Android bundle
 assertIncludes(androidBuildSource, "EventEmitterModule.java", "Android bundle builder must patch Expo event dispatcher Java deprecations");
 assertIncludes(androidBuildSource, "-Xlint:none", "Android bundle builder must suppress upstream Expo Java deprecation notes");
 assertIncludes(androidBuildSource, "./lib/build-environment.mjs", "Android bundle builder must import the shared build environment module");
+assertIncludes(androidBuildSource, "...NPM_CI_ARGUMENTS", "Android bundle builder must use the shared npm ci arguments");
 assertIncludes(androidBuildEnvironmentSource, "delete environment.FORCE_COLOR", "Android bundle builder must avoid Metro color environment warnings");
 assertIncludes(androidBuildEnvironmentSource, "delete environment.NODE_ENV", "Android bundle builder must keep the npm ci step free of the caller NODE_ENV");
+assertIncludes(androidBuildEnvironmentSource, '"--include=dev"', "Android bundle builder must force npm to install dev dependencies");
 
 console.log("Social Threader mobile config validation passed.");
 

--- a/mobile/scripts/validate-config.mjs
+++ b/mobile/scripts/validate-config.mjs
@@ -26,6 +26,7 @@ const deploymentManifestSource = fs.readFileSync(
 );
 const appSource = fs.readFileSync(path.join(MOBILE_ROOT, "App.js"), "utf8");
 const androidBuildSource = fs.readFileSync(path.join(MOBILE_ROOT, "scripts", "build-android-bundle.mjs"), "utf8");
+const androidBuildEnvironmentSource = fs.readFileSync(path.join(MOBILE_ROOT, "scripts", "lib", "build-environment.mjs"), "utf8");
 const androidPublishSource = fs.readFileSync(path.join(MOBILE_ROOT, "scripts", "publish-android-play.mjs"), "utf8");
 const jestConfigSource = fs.readFileSync(path.join(MOBILE_ROOT, "jest.config.js"), "utf8");
 
@@ -160,7 +161,9 @@ assertIncludes(androidBuildSource, "NativeModulesProxyModule.kt", "Android bundl
 assertIncludes(androidBuildSource, "ModuleRegistryAdapter.java", "Android bundle builder must patch Expo ReactPackage Java deprecations");
 assertIncludes(androidBuildSource, "EventEmitterModule.java", "Android bundle builder must patch Expo event dispatcher Java deprecations");
 assertIncludes(androidBuildSource, "-Xlint:none", "Android bundle builder must suppress upstream Expo Java deprecation notes");
-assertIncludes(androidBuildSource, "delete environment.FORCE_COLOR", "Android bundle builder must avoid Metro color environment warnings");
+assertIncludes(androidBuildSource, "./lib/build-environment.mjs", "Android bundle builder must import the shared build environment module");
+assertIncludes(androidBuildEnvironmentSource, "delete environment.FORCE_COLOR", "Android bundle builder must avoid Metro color environment warnings");
+assertIncludes(androidBuildEnvironmentSource, "delete environment.NODE_ENV", "Android bundle builder must keep the npm ci step free of the caller NODE_ENV");
 
 console.log("Social Threader mobile config validation passed.");
 


### PR DESCRIPTION
## Summary

- Ensure Android bundle builds install mobile devDependencies even when the caller provides `NODE_ENV=production`.
- Move Android build-environment construction into a shared module that removes inherited `NODE_ENV` while preserving the production setting applied specifically to Gradle.
- Add regression coverage that runs `npm ci` under a production caller environment and verifies `babel-preset-expo` is installed.
- Update configuration validation and mobile build documentation to enforce and describe the environment contract.
- Document credential-discovery policy and release-related terminology.