### PR TITLE
I001: Freeze the selected manifest as a versionless contract

### DIFF
--- a/.mprlab/AGENTS.DOCKER.md
+++ b/.mprlab/AGENTS.DOCKER.md
@@ -19,7 +19,7 @@ Docker and container guidance for this repository. Use this guide only when Dock
 
 - Treat local orchestration and production orchestration as different contracts.
 - MPR Lab has no current plan to put these contracts together.
-- Keep app-owned local orchestration during a migration to `schema_version: 3`.
+- Keep app-owned local orchestration separate from the versionless selected-manifest contract.
 - A local topology can be different from the production topology.
 - Keep local orchestration files outside `.mprlab/deploy/`.
 - Do not use local orchestration files as production lifecycle inputs.

--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -39,6 +39,9 @@ Format: `- [ ] [B042] (P1) {I007} Title`
 
 ## Improvements
 
+- [x] [I001] (P1) Freeze the selected manifest as a versionless contract
+  Resolved: removed the numbered manifest envelope and stale mobile publication member, kept only current typed resources, and added a contract test that rejects numbered envelope drift.
+
 ## Maintenance
 
 - [ ] [M400R] (P2) Backlog hygiene and archive

--- a/.mprlab/deploy/resources.yml
+++ b/.mprlab/deploy/resources.yml
@@ -1,6 +1,5 @@
 ---
 mprlab_resources:
-  schema_version: 4
   owner: social-threader
   release:
     scheme: semver
@@ -115,8 +114,6 @@ mprlab_resources:
       build_system: local
       build:
         android: mobile/scripts/build-android-bundle.mjs
-      publish:
-        android: mobile/scripts/publish-android-play.mjs
       android:
         package_name: com.mprlab.socialthreader
         destination: google_play

--- a/README.md
+++ b/README.md
@@ -170,11 +170,11 @@ Run the mobile validation gate:
 make mobile-check
 ```
 
-The schema-v4 manifest preserves the Android store artifact. Native thread transformation needs its own TAuth profile and session contract.
+The versionless manifest preserves the Android store artifact. Native thread transformation needs its own TAuth profile and session contract.
 
 ## Release, Publish, And Deployment
 
-`.mprlab/deploy/resources.yml` is the only tracked production deployment manifest. It uses `schema_version: 4` and the SemVer release scheme.
+`.mprlab/deploy/resources.yml` is the only tracked production deployment manifest. Its permanent versionless contract uses the SemVer release scheme.
 
 The manifest declares these resources:
 
@@ -185,7 +185,7 @@ The manifest declares these resources:
 - The TAuth tenant contribution.
 - The dedicated private values.
 
-The Android resource uses repository-owned local build and publish scripts. The publisher supports preflight, exact reconciliation, and submission.
+The Android resource uses the repository-owned local build script. The store tooling supports preflight, exact reconciliation, and submission.
 
 The gateway adds `CNAME`, `.nojekyll`, and the release marker to the Pages artifact. Application source does not own these files.
 

--- a/doc.md
+++ b/doc.md
@@ -111,7 +111,7 @@ Browser analytics must not receive source text, transformed text, prompts, or cr
 
 `docker-compose.yml` owns local orchestration. It connects Caddy, the API, TAuth, and the fake LLM Proxy.
 
-`.mprlab/deploy/resources.yml` owns production orchestration. It declares schema-v4 resources for the sibling gateway.
+`.mprlab/deploy/resources.yml` owns production orchestration. It declares the permanent versionless resources for the sibling gateway.
 
 The manifest owns the SemVer release scheme. The removed `.mprlab/release.yml` file does not define a second release contract.
 

--- a/internal/deployment/contract_test.go
+++ b/internal/deployment/contract_test.go
@@ -16,10 +16,9 @@ type manifestDocument struct {
 }
 
 type manifestEnvelope struct {
-	SchemaVersion int                `yaml:"schema_version"`
-	Owner         string             `yaml:"owner"`
-	Release       manifestRelease    `yaml:"release"`
-	Resources     []manifestResource `yaml:"resources"`
+	Owner     string             `yaml:"owner"`
+	Release   manifestRelease    `yaml:"release"`
+	Resources []manifestResource `yaml:"resources"`
 }
 
 type manifestRelease struct {
@@ -31,7 +30,6 @@ type manifestResource struct {
 	ID          string            `yaml:"id"`
 	BuildSystem string            `yaml:"build_system"`
 	Build       map[string]string `yaml:"build"`
-	Publish     map[string]string `yaml:"publish"`
 }
 
 type localComposeDocument struct {
@@ -70,8 +68,24 @@ func TestProductionLifecycleContract(t *testing.T) {
 	if unmarshalError := yaml.Unmarshal(manifestBytes, &document); unmarshalError != nil {
 		t.Fatalf("deployment manifest must be valid YAML: %v", unmarshalError)
 	}
-	if document.Resources.SchemaVersion != 4 {
-		t.Fatalf("schema version = %d, want 4", document.Resources.SchemaVersion)
+	var manifestShape map[string]any
+	if unmarshalError := yaml.Unmarshal(manifestBytes, &manifestShape); unmarshalError != nil {
+		t.Fatalf("deployment manifest shape must be valid YAML: %v", unmarshalError)
+	}
+	resourceEnvelopeShape, shapeOK := manifestShape["mprlab_resources"].(map[string]any)
+	if !shapeOK {
+		t.Fatal("deployment manifest must contain the mprlab_resources mapping")
+	}
+	if len(resourceEnvelopeShape) != 3 {
+		t.Fatalf("manifest envelope keys = %#v, want owner, release, and resources", resourceEnvelopeShape)
+	}
+	for _, requiredKey := range []string{"owner", "release", "resources"} {
+		if _, present := resourceEnvelopeShape[requiredKey]; !present {
+			t.Fatalf("manifest envelope lacks %q", requiredKey)
+		}
+	}
+	if _, present := resourceEnvelopeShape["schema_version"]; present {
+		t.Fatal("selected manifest must not declare schema_version")
 	}
 	if document.Resources.Owner != "social-threader" {
 		t.Fatalf("manifest owner = %q, want social-threader", document.Resources.Owner)
@@ -111,9 +125,6 @@ func TestProductionLifecycleContract(t *testing.T) {
 		}
 		if resource.Build["android"] != "mobile/scripts/build-android-bundle.mjs" {
 			t.Errorf("mobile Android build script = %q", resource.Build["android"])
-		}
-		if resource.Publish["android"] != "mobile/scripts/publish-android-play.mjs" {
-			t.Errorf("mobile Android publish script = %q", resource.Publish["android"])
 		}
 	}
 

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -8,9 +8,9 @@
       "name": "social-threader-mobile",
       "version": "0.1.0",
       "dependencies": {
-        "expo": "57.0.14",
+        "expo": "57.0.15",
         "expo-clipboard": "57.0.1",
-        "expo-image-picker": "57.0.11",
+        "expo-image-picker": "57.0.12",
         "expo-status-bar": "57.0.1",
         "react": "19.2.3",
         "react-dom": "19.2.3",
@@ -1417,9 +1417,9 @@
       "license": "MIT"
     },
     "node_modules/@expo/fingerprint": {
-      "version": "0.20.8",
-      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.20.8.tgz",
-      "integrity": "sha512-0UOg9dVepR0LO4iUacoFuWZ9GNSUdUkdx9GX+Rj0mRpOTAtavyiem8IfewCAHij3cppqjBic134JD2lUxsZcJw==",
+      "version": "0.20.9",
+      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.20.9.tgz",
+      "integrity": "sha512-h+YvPyNmeAUCCqaXvftiXklA2zGyRcIPv1B8fFS0YSIgNhwcxFGh1EyLOMsvJ2aWsBViNtIJ1HIFLzNu43/r4w==",
       "license": "MIT",
       "dependencies": {
         "@expo/env": "^2.4.2",
@@ -1473,12 +1473,12 @@
       }
     },
     "node_modules/@expo/local-build-cache-provider": {
-      "version": "57.0.6",
-      "resolved": "https://registry.npmjs.org/@expo/local-build-cache-provider/-/local-build-cache-provider-57.0.6.tgz",
-      "integrity": "sha512-6aFMROb1SzIvrefpwhgS5QGNELU9T2lpK0Hcl6oiZ4/mbKgZRk0WEPauo/dHH6IgDmyK25InCMHF5nj7XY4LWg==",
+      "version": "57.0.7",
+      "resolved": "https://registry.npmjs.org/@expo/local-build-cache-provider/-/local-build-cache-provider-57.0.7.tgz",
+      "integrity": "sha512-Hq5xWhXJWuyH3CWh3uqDWoHtxM0XYqLs9h2OzRWImBJahCPfePOo4kmw2uTEB6qHT5T47eqO4jtDG3MRGGZCpw==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config": "~57.0.7",
+        "@expo/config": "~57.0.8",
         "chalk": "^4.1.2"
       }
     },
@@ -1522,15 +1522,15 @@
       }
     },
     "node_modules/@expo/metro-config": {
-      "version": "57.0.8",
-      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-57.0.8.tgz",
-      "integrity": "sha512-cZOVjbljqRBMCXcloc5k23gsFOhWdiKXhDkp5jU/wY6IXR6G7cYtNOwxKfxI1QLhs0KcXY0gDmZ2UIueoHzY7g==",
+      "version": "57.0.9",
+      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-57.0.9.tgz",
+      "integrity": "sha512-+lalXZdoMaKTG1uKXsi2KWO0f7H3KiWrhZzAla4EmNSkcUMRx6K1rhZuBYoaJaKIp9BHZ333KbqRPron7slKQA==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
         "@babel/core": "^7.20.0",
         "@babel/generator": "^7.20.5",
-        "@expo/config": "~57.0.7",
+        "@expo/config": "~57.0.8",
         "@expo/env": "~2.4.2",
         "@expo/json-file": "~11.0.1",
         "@expo/metro": "~56.0.0",
@@ -1721,12 +1721,12 @@
       }
     },
     "node_modules/@expo/prebuild-config": {
-      "version": "57.0.12",
-      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-57.0.12.tgz",
-      "integrity": "sha512-3vwrQ2DSGijJUa8K/j3xUfOdhYgygKdWAjJ7o3r143BGnKD1SwPIMEN7dSDhkmDWR4FAXTQwgaD8dHh5VZd/jA==",
+      "version": "57.0.13",
+      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-57.0.13.tgz",
+      "integrity": "sha512-VhSySuXqOwK4fIc+9rgms7zN+c1Khj2xpuIgpVLPNyWRtpS8wB+eyV5CSohjSUBa3h+NsFdPk/VG6p0ZwlMDrg==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config": "~57.0.7",
+        "@expo/config": "~57.0.8",
         "@expo/config-plugins": "~57.0.8",
         "@expo/config-types": "^57.0.2",
         "@expo/image-utils": "^0.11.4",
@@ -4204,31 +4204,31 @@
       }
     },
     "node_modules/expo": {
-      "version": "57.0.14",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-57.0.14.tgz",
-      "integrity": "sha512-vJ7V/VNr2IGxhhBdRs1qDExPbEe+DvfqVGp3818gyfr4k0l7mdBb1QuDFH0VCX6wT9/18EYxW7SQca4tXkzDYw==",
+      "version": "57.0.15",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-57.0.15.tgz",
+      "integrity": "sha512-9UooISw8S8Gxo9wpsPcGkyRlf2UzNr+F26LSU2+M8iaiZ1WAjPR0I75NKFX8ETbrSgthZ2lQHgy5IU2KE/mpBA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
-        "@expo/cli": "^57.0.16",
+        "@expo/cli": "^57.0.17",
         "@expo/config": "~57.0.8",
         "@expo/config-plugins": "~57.0.8",
         "@expo/devtools": "~57.0.1",
         "@expo/dom-webview": "~57.0.1",
-        "@expo/fingerprint": "^0.20.8",
-        "@expo/local-build-cache-provider": "^57.0.6",
+        "@expo/fingerprint": "^0.20.9",
+        "@expo/local-build-cache-provider": "^57.0.7",
         "@expo/log-box": "^57.0.3",
         "@expo/metro": "~56.0.0",
-        "@expo/metro-config": "~57.0.8",
+        "@expo/metro-config": "~57.0.9",
         "@ungap/structured-clone": "^1.3.0",
         "babel-preset-expo": "~57.0.7",
-        "expo-asset": "~57.0.12",
-        "expo-constants": "~57.0.12",
-        "expo-file-system": "~57.0.4",
+        "expo-asset": "~57.0.13",
+        "expo-constants": "~57.0.13",
+        "expo-file-system": "~57.0.5",
         "expo-font": "~57.0.1",
         "expo-keep-awake": "~57.0.1",
         "expo-modules-autolinking": "~57.0.10",
-        "expo-modules-core": "~57.0.11",
+        "expo-modules-core": "~57.0.12",
         "pretty-format": "^29.7.0",
         "react-refresh": "^0.14.2",
         "whatwg-url-minimum": "^0.1.2"
@@ -4266,13 +4266,13 @@
       }
     },
     "node_modules/expo-asset": {
-      "version": "57.0.12",
-      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-57.0.12.tgz",
-      "integrity": "sha512-DbNxGsmqCaE2LWyabXEkDqV/8/mrZ2ikmVzi1V1Dp4MaQO9Kde6VcvQk7h6NVsklmo4xPT1J2Lnrs8Vd18sXOg==",
+      "version": "57.0.13",
+      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-57.0.13.tgz",
+      "integrity": "sha512-RPjMcmPXRMb6UbQdTIkmSDEnQL5LKGTu7ZXatq3U67V6ldlSdQeQ9pQV7zlmk0DrbnaMEh3HYiEh2YxWLNyCzA==",
       "license": "MIT",
       "dependencies": {
         "@expo/image-utils": "^0.11.4",
-        "expo-constants": "~57.0.12"
+        "expo-constants": "~57.0.13"
       },
       "peerDependencies": {
         "expo": "*",
@@ -4292,9 +4292,9 @@
       }
     },
     "node_modules/expo-constants": {
-      "version": "57.0.12",
-      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-57.0.12.tgz",
-      "integrity": "sha512-js9qxZw4G9ulSc72GGpYGwtmk/IzFcf6/tTcEG6wB8HTlkunMS4W86R+4e6oHIrIkHA7W6s/79Se+E+DC3RAqA==",
+      "version": "57.0.13",
+      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-57.0.13.tgz",
+      "integrity": "sha512-eB5AHp7kKxsVIBjTetUgj5WQSw8joI2ekzgTlcUv+Hc0x2t0jZU6IiL4DpyOT2yZQ71n0WJZCkmOKLgxlajIzg==",
       "license": "MIT",
       "dependencies": {
         "@expo/env": "~2.4.2"
@@ -4305,9 +4305,9 @@
       }
     },
     "node_modules/expo-file-system": {
-      "version": "57.0.4",
-      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-57.0.4.tgz",
-      "integrity": "sha512-h8qDOxSW1SQfnZyvH0+HeOfXCr2X4v3x50+d19JuyQcjDR+JA3tng20TlQxIHazzLPPbwtSKA1Dj3+XIOpnoKg==",
+      "version": "57.0.5",
+      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-57.0.5.tgz",
+      "integrity": "sha512-XjGrCClF0935y5wLB9qNQQUVptNEy+0OloBstXlCd+IeNXLo3uNOod6cX4N0hofIhNIrN1Al8fwfay7R0Z1a2A==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",
@@ -4338,9 +4338,9 @@
       }
     },
     "node_modules/expo-image-picker": {
-      "version": "57.0.11",
-      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-57.0.11.tgz",
-      "integrity": "sha512-CyeQuGeA2Jei8zQb8S2fxmK6OIvdvUOYpxXegy8Dyc2WsI0GfWcgH8f+6uZmBaMlxakMPP4cfNvT1LeSMbB0PA==",
+      "version": "57.0.12",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-57.0.12.tgz",
+      "integrity": "sha512-BjZLioItcDNrXwp46XZDZGDEUJ16/bK0QzxPjdNijiPYpLfQLeuFYoX9yH31sosnli0UL++x4ndYQoTMsICdlw==",
       "license": "MIT",
       "dependencies": {
         "expo-image-loader": "~57.0.1"
@@ -4375,13 +4375,13 @@
       }
     },
     "node_modules/expo-modules-core": {
-      "version": "57.0.11",
-      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-57.0.11.tgz",
-      "integrity": "sha512-gzRAI+vs0g9eObyQfGq1kp017flMeqZMzprqquCWxKg/AYdJXKmGXibJqMVFvRbUpluYBsW8U9P0inntKbzJOg==",
+      "version": "57.0.12",
+      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-57.0.12.tgz",
+      "integrity": "sha512-hKqCdu8+78oNKWCgM4xSeblfmD/audgNVCn6uUCJuNBS/hc4DyC0Ia1X96SSZF9w9bGTLjNS8j2b7DshiC3WJA==",
       "license": "MIT",
       "dependencies": {
         "@expo/expo-modules-macros-plugin": "0.6.1",
-        "expo-modules-jsi": "~57.0.4",
+        "expo-modules-jsi": "~57.0.5",
         "invariant": "^2.2.4"
       },
       "peerDependencies": {
@@ -4396,9 +4396,9 @@
       }
     },
     "node_modules/expo-modules-jsi": {
-      "version": "57.0.4",
-      "resolved": "https://registry.npmjs.org/expo-modules-jsi/-/expo-modules-jsi-57.0.4.tgz",
-      "integrity": "sha512-vt7FyqUqqFXiRVnBqYD7y+GSPTgeua5Ocoy0+SYt+RSHkZEA2Fyop7If3g1TYDzQObYybPRo7TG2Rle1XLaWFw==",
+      "version": "57.0.5",
+      "resolved": "https://registry.npmjs.org/expo-modules-jsi/-/expo-modules-jsi-57.0.5.tgz",
+      "integrity": "sha512-NQF7MUF0j3rQHV8KJqETYA1SrJr3USvQ/AWEhODo+unMRFBDP9BKpn8+aNGGmx6fa2XLnqC2qulVw4DT6Gp13Q==",
       "license": "MIT",
       "peerDependencies": {
         "react-native": "*"
@@ -4425,9 +4425,9 @@
       }
     },
     "node_modules/expo/node_modules/@expo/cli": {
-      "version": "57.0.16",
-      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-57.0.16.tgz",
-      "integrity": "sha512-+HyMY2nAS6QBJb0nSeMz92p11bZ1AtWSRnhWnklznN07IRoQirisnKq2vr18Ayjb/fnb5F/um+n6FRhF0fZm1Q==",
+      "version": "57.0.17",
+      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-57.0.17.tgz",
+      "integrity": "sha512-PQc7if117dNh2qe+CHdlmSWpgwhFiP9CJ7XbwNF0w4KSKxFpJ2qUjDPoAcCMW1VZg1x30mEJ907bT8G1iDIZBQ==",
       "license": "MIT",
       "dependencies": {
         "@expo/code-signing-certificates": "^0.0.6",
@@ -4440,21 +4440,21 @@
         "@expo/json-file": "^11.0.1",
         "@expo/log-box": "^57.0.3",
         "@expo/metro": "~56.0.0",
-        "@expo/metro-config": "~57.0.8",
+        "@expo/metro-config": "~57.0.9",
         "@expo/metro-file-map": "^57.0.1",
         "@expo/osascript": "^2.7.1",
         "@expo/package-manager": "^1.13.1",
         "@expo/plist": "^0.8.1",
-        "@expo/prebuild-config": "^57.0.12",
+        "@expo/prebuild-config": "^57.0.13",
         "@expo/require-utils": "^57.0.4",
-        "@expo/router-server": "^57.0.6",
+        "@expo/router-server": "^57.0.7",
         "@expo/schema-utils": "^57.0.2",
         "@expo/spawn-async": "^1.8.0",
         "@expo/ws-tunnel": "^2.0.0",
         "@expo/xcpretty": "^4.4.4",
         "@react-native/dev-middleware": "0.86.2",
         "accepts": "^1.3.8",
-        "agent-cli-detector": "^0.1.2",
+        "agent-cli-detector": "0.1.6",
         "arg": "^5.0.2",
         "bplist-creator": "0.1.0",
         "bplist-parser": "^0.3.1",
@@ -4508,17 +4508,17 @@
       }
     },
     "node_modules/expo/node_modules/@expo/cli/node_modules/@expo/router-server": {
-      "version": "57.0.6",
-      "resolved": "https://registry.npmjs.org/@expo/router-server/-/router-server-57.0.6.tgz",
-      "integrity": "sha512-/0H7OIilU4lmdR3V9UZuKou71cwaJ11sneW8/T6Rtr46LA71lgBWzdRldvVxaWv8dT+cu90f4jl+M3DYXN9MqQ==",
+      "version": "57.0.7",
+      "resolved": "https://registry.npmjs.org/@expo/router-server/-/router-server-57.0.7.tgz",
+      "integrity": "sha512-QFHwt6V7UovmYA7+8BoMeKj3fh6WtkM9zksKjNAlZdcEI/hUhcW4uged6So5yc4tq+eA60kA7gIVZPKgBIZdrQ==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4"
       },
       "peerDependencies": {
-        "@expo/metro-runtime": "^57.0.10",
+        "@expo/metro-runtime": "^57.0.12",
         "expo": "*",
-        "expo-constants": "^57.0.11",
+        "expo-constants": "^57.0.13",
         "expo-font": "^57.0.1",
         "expo-router": "*",
         "expo-server": "^57.0.3",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -22,9 +22,9 @@
     "check": "npm run sync-shared && npm run test:coverage && node scripts/validate-config.mjs && npx --no-install expo config --type public >/dev/null && npx --no-install expo install --check && npm run bundle:check"
   },
   "dependencies": {
-    "expo": "57.0.14",
+    "expo": "57.0.15",
     "expo-clipboard": "57.0.1",
-    "expo-image-picker": "57.0.11",
+    "expo-image-picker": "57.0.12",
     "expo-status-bar": "57.0.1",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/mobile/scripts/validate-config.mjs
+++ b/mobile/scripts/validate-config.mjs
@@ -132,13 +132,12 @@ assertNotIncludes(
 );
 assertIncludes(makefileSource, "mobile-android-bundle: mobile-check", "the Android development build helper must remain available");
 assertIncludes(makefileSource, "submit-android:", "the Android development publish helper must remain available");
-assertIncludes(deploymentManifestSource, "schema_version: 4", "the canonical manifest must use resource schema 4");
+assertNotIncludes(deploymentManifestSource, "schema_version:", "the canonical manifest must remain versionless");
 assertIncludes(deploymentManifestSource, "scheme: semver", "the canonical manifest must own the SemVer release scheme");
 assertIncludes(deploymentManifestSource, "kind: mobile_application", "the canonical manifest must declare the mobile artifact");
 assertIncludes(deploymentManifestSource, "source: mobile", "the mobile resource must use the mobile source folder");
 assertIncludes(deploymentManifestSource, "build_system: local", "the mobile resource must use repository-owned local scripts");
 assertIncludes(deploymentManifestSource, "android: mobile/scripts/build-android-bundle.mjs", "the mobile resource must declare the Android builder");
-assertIncludes(deploymentManifestSource, "android: mobile/scripts/publish-android-play.mjs", "the mobile resource must declare the Android publisher");
 assertIncludes(deploymentManifestSource, "package_name: com.mprlab.socialthreader", "the mobile resource must use the Android package");
 assertIncludes(deploymentManifestSource, "track: production", "the mobile resource must declare the production destination track");
 assertIncludes(androidBuildSource, "releaseIdentity.googleCloudProjectId", "Android bundle builder must use the release identity quota project");

--- a/mobile/scripts/validate-config.mjs
+++ b/mobile/scripts/validate-config.mjs
@@ -35,11 +35,11 @@ assertIncludes(packageJson.scripts?.check || "", "npm run test:coverage", "mobil
 assertIncludes(packageJson.scripts?.check || "", "expo install --check", "mobile check must validate Expo dependency alignment");
 assertIncludes(packageJson.scripts?.ios || "", "scripts/ios-run.mjs", "iOS local run must use the prompt-safe Expo launcher");
 assertIncludes(packageJson.scripts?.android || "", "scripts/android-run.mjs", "Android local run must use the adb reverse launcher");
-assertEqual(packageJson.dependencies?.expo, "57.0.14", "mobile package must use the Expo SDK 57 runtime");
+assertEqual(packageJson.dependencies?.expo, "57.0.15", "mobile package must use the Expo SDK 57 runtime");
 assertEqual(packageJson.dependencies?.react, "19.2.3", "mobile package must use the Expo SDK React version");
 assertEqual(packageJson.dependencies?.["react-native"], "0.86.2", "mobile package must use the Expo SDK React Native version");
 assertEqual(packageJson.dependencies?.["expo-clipboard"], "57.0.1", "mobile package must use Expo SDK clipboard for native image copies");
-assertEqual(packageJson.dependencies?.["expo-image-picker"], "57.0.11", "mobile package must use Expo SDK image picker for native image attachments");
+assertEqual(packageJson.dependencies?.["expo-image-picker"], "57.0.12", "mobile package must use Expo SDK image picker for native image attachments");
 assertEqual(packageJson.dependencies?.["expo-status-bar"], "57.0.1", "mobile package must use Expo SDK status bar");
 assertEqual(packageJson.dependencies?.["expo-sharing"], undefined, "mobile package must not keep the old native image sharing dependency");
 assertEqual(


### PR DESCRIPTION
## Summary

- Remove `schema_version` from the selected-application manifest and reject numbered envelope drift.
- Remove the obsolete mobile publication member while preserving repository-owned store tooling.
- Align Expo and Expo Image Picker with the current SDK 57 compatibility matrix and keep the mobile config guard current.
- Update current lifecycle documentation and Docker governance to describe the permanent versionless contract.

Head commit: `00c0e4138bba9e6019d1798b595fad5c4daaafea`

## Validation

- Focused mobile compatibility: PASS — `npm run check`; 27 mobile tests at 100% coverage, Expo dependency validation, and iOS/Android bundle checks passed.
- Local CI: PASS — `PUPPETEER_EXECUTABLE_PATH='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' make ci`; 43 headless tests, 6 browser tests, all Go gates, and the full mobile gate passed.
- Hosted CI: PASS — [`Browser, API, and container checks` job 96642256122](https://github.com/MarcoPoloResearchLab/social_threader/actions/runs/32437741102/job/96642256122) and [`Mobile checks` job 96642255832](https://github.com/MarcoPoloResearchLab/social_threader/actions/runs/32437741102/job/96642255832).
- Gateway plan: PASS — disposable normal clones pinned to gateway `753c72737cf44bdd526afca71570fc900d7e4ba9` and app `00c0e4138bba9e6019d1798b595fad5c4daaafea` completed `make plan-app-release`.

## Dependency

Depends on https://github.com/MarcoPoloResearchLab/mprlab-gateway/pull/287

No release, publication, deployment, or production action was run.
