### PR TITLE
B003: derive Android release version code

### DIFF
--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -8,6 +8,34 @@ Format: `- [ ] [B042] (P1) {I007} Title`
 
 ## BugFixes
 
+- [x] [B003] (P0) Derive the Android version code from the release timestamp
+  Goal:
+  Each sealed Android release must use a new store build number.
+
+  Evidence:
+  - The release builder used the permanent `versionCode: 1` value from `mobile/app.json`.
+  - Google Play already contains version code 1 with a different Android App Bundle.
+  - Google Play does not permit a replacement for an existing version code.
+
+  Requirements:
+  - Derive the release version code from the sealed UTC release timestamp.
+  - Use seconds since `2020-01-01T00:00:00Z` as the build number.
+  - Keep the source app config for local development builds only.
+  - Reject a timestamp that cannot produce a valid Google Play version code.
+
+  Validation:
+  - Add deterministic tests for valid, invalid, early, and out-of-range timestamps.
+  - Run `make mobile-check` after the test change.
+  - Run `make ci` after the last source change.
+  - Release, publish, and deploy the successor with the repository lifecycle.
+
+  Resolution:
+  - The release builder derives the Android version code from the sealed UTC release timestamp.
+  - Local development builds continue to use the source app config.
+  - The first focused gate failed because the build-number module was absent.
+  - The focused gate passed all 32 mobile tests after the source change.
+  - The final `make ci` gate passed after the last source change.
+
 - [x] [B002] (P0) Install the exact mobile dependency lock in CI
   Goal:
   Canonical CI must validate the mobile dependencies that the current lockfile specifies.

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -59,7 +59,8 @@ Keep App Store Connect keys, Google service account JSON files, Android upload k
   - iOS bundle identifier: `com.mprlab.socialthreader`
   - Android package name: `com.mprlab.socialthreader`
 - [ ] Confirm the Apple Developer agreement and Google Play Console account setup are current.
-- [ ] Update `expo.version`, `ios.buildNumber`, and `android.versionCode` in `app.json`.
+- [ ] Update `expo.version` and `ios.buildNumber` in `app.json`.
+- [ ] Let the gateway release timestamp set the Android `versionCode`.
 - [ ] Confirm privacy policy URL, support URL, description, screenshots, app category, content rating, and release notes are ready in both stores.
 - [ ] Run:
 

--- a/mobile/__tests__/releaseBuildNumber.test.js
+++ b/mobile/__tests__/releaseBuildNumber.test.js
@@ -1,0 +1,16 @@
+import { releaseBuildNumber } from "../scripts/release-build-number.mjs";
+
+describe("Android release build number", () => {
+  it("uses UTC seconds since the release epoch", () => {
+    expect(releaseBuildNumber("2026-08-22T00:00:00Z")).toBe(209520000);
+  });
+
+  it.each([
+    ["", TypeError],
+    ["2026-08-22", TypeError],
+    ["2019-12-31T23:59:59Z", RangeError],
+    ["2086-07-22T02:40:01Z", RangeError]
+  ])("rejects %p", (timestamp, expectedError) => {
+    expect(() => releaseBuildNumber(timestamp)).toThrow(expectedError);
+  });
+});

--- a/mobile/scripts/build-android-bundle.mjs
+++ b/mobile/scripts/build-android-bundle.mjs
@@ -10,6 +10,7 @@ import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 import { buildEnvironment, NPM_CI_ARGUMENTS } from "./lib/build-environment.mjs";
+import { releaseBuildNumber } from "./release-build-number.mjs";
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(SCRIPT_DIR, "../..");
@@ -151,7 +152,7 @@ function parseLifecycleVersioning(artifactVersion, releaseTimestamp) {
  */
 function buildAndroidBundle(args) {
   const appConfig = readAppConfig(args.mobileDir);
-  const versionCodeResolution = resolveVersionCode(args.versionCode, appConfig, args.quotaProject);
+  const versionCodeResolution = resolveBuildVersionCode(args, appConfig);
   const signing = readSigningProperties(args.keystoreProperties, args.keystore);
   const expectedUploadKeySha256 = readExpectedUploadKeySha256(args.mobileDir);
   const uploadKeySha256 = verifyUploadKeyFingerprint(signing, args.javaHome, expectedUploadKeySha256);
@@ -250,6 +251,27 @@ function buildAndroidBundle(args) {
   }
   metadata.buildManifest = writeBuildManifest(outputPath, metadata);
   return metadata;
+}
+
+/**
+ * @param {BundleArgs} args
+ * @param {{ versionCode: number; packageName: string }} appConfig
+ * @returns {{ versionCode: number; source: string; policy: string; googlePlayMaxVersionCode: number | null }}
+ */
+function resolveBuildVersionCode(args, appConfig) {
+  if (!args.versioning) {
+    return resolveVersionCode(args.versionCode, appConfig, args.quotaProject);
+  }
+  try {
+    return {
+      versionCode: releaseBuildNumber(args.versioning.releaseTimestamp),
+      source: "release_timestamp",
+      policy: "UTC release timestamp seconds since 2020-01-01",
+      googlePlayMaxVersionCode: null
+    };
+  } catch (error) {
+    throw new BuildError(error instanceof Error ? error.message : String(error));
+  }
 }
 
 /**

--- a/mobile/scripts/release-build-number.mjs
+++ b/mobile/scripts/release-build-number.mjs
@@ -1,0 +1,27 @@
+// @ts-check
+
+const releaseEpochMilliseconds = Date.UTC(2020, 0, 1);
+const maximumStoreBuildNumber = 2_100_000_000;
+
+/**
+ * @param {string} timestamp
+ * @returns {number}
+ */
+export function releaseBuildNumber(timestamp) {
+  if (typeof timestamp !== "string" || !timestamp || timestamp.trim() !== timestamp) {
+    throw new TypeError("release timestamp must be canonical UTC RFC 3339 text");
+  }
+  const milliseconds = Date.parse(timestamp);
+  if (!Number.isFinite(milliseconds)) {
+    throw new TypeError("release timestamp must be canonical UTC RFC 3339 text");
+  }
+  const canonicalTimestamp = new Date(milliseconds).toISOString().replace(".000Z", "Z");
+  if (canonicalTimestamp !== timestamp.replace(".000Z", "Z")) {
+    throw new TypeError("release timestamp must be canonical UTC RFC 3339 text");
+  }
+  const buildNumber = Math.floor((milliseconds - releaseEpochMilliseconds) / 1000);
+  if (buildNumber <= 0 || buildNumber > maximumStoreBuildNumber) {
+    throw new RangeError("release timestamp cannot produce a store build number");
+  }
+  return buildNumber;
+}

--- a/mobile/scripts/validate-config.mjs
+++ b/mobile/scripts/validate-config.mjs
@@ -143,6 +143,11 @@ assertIncludes(deploymentManifestSource, "track: production", "the mobile resour
 assertIncludes(androidBuildSource, "releaseIdentity.googleCloudProjectId", "Android bundle builder must use the release identity quota project");
 assertIncludes(androidBuildSource, "MPRLAB_ARTIFACT_VERSION", "Android bundle builder must seal the gateway artifact version");
 assertIncludes(androidBuildSource, "releaseTimestamp", "Android bundle builder must seal the gateway release timestamp");
+assertIncludes(
+  androidBuildSource,
+  "releaseBuildNumber(args.versioning.releaseTimestamp)",
+  "Android release version code must use the sealed gateway release timestamp"
+);
 assertIncludes(androidPublishSource, "PROVIDER_MODES.RECONCILE", "Android publisher must reconcile an interrupted publication");
 assertIncludes(androidPublishSource, 'publisherAccess: "verified"', "Android publisher must report verified provider access");
 assertIncludes(


### PR DESCRIPTION
Summary:
- Derive lifecycle Android version codes from the sealed UTC release timestamp.
- Keep app.json versionCode for local development builds only.
- Add deterministic release build-number tests and update the store runbook.

Validation:
- Red: make mobile-check failed because the release build-number module was absent.
- Green: make mobile-check passed 32 mobile tests.
- Final: make ci passed.
- git diff --check passed.

Operational status:
- Release, publication, deployment, and store acceptance remain separate and will run after merge.